### PR TITLE
v74.1-1.0.0 [Synapse break. Vanishment, this world! ]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 Changelog
 ---
 
+# 74.1-1.0.0 [Synapse break. Vanishment, this world!]
+
+**4 New Dark Themes!**
+
+- Decimate errors in the code alongside the Wicked Lord Shingan. Let your inner fantasies go rampant with Rikka Takanashi from: "Love, Chuunibyou, and Other Delusions". 
+- It is comfy time! Don't let feature requests stress you out, because you can now code with Nadeshiko from Yuru Camp. 
+- A Certain Scientific RailGun go: bzzzzzzt. Zap bugs out of existence with the electromaster Mikoto Misaka.
+- Raccoon + Tanuki = one really cute cinnamon bun. Enjoy your time coding with Raphtalia from: "Rising of the Shield Hero."
+
+![v74 Girls](https://doki.assets.unthrottled.io/misc/v74_girls.png)
+
+### Other Stuff
+
+- Updated Syntax Highlight & Look and Feel changes for the following legacy themes: Ibuki Dark, Astolfo, Aqua, Hatsune Miku, Emilia Dark, Ram, and Rem.
+
 # 15.0.0 [Syntax Highlighting Revisited]
 
 - Updated all the syntax highlighting themes to be consistent with the rest of the platform.

--- a/autoload/aqua.vim
+++ b/autoload/aqua.vim
@@ -2,7 +2,7 @@
 
 let s:colors = {
       \ "comments": { "gui": "#6272a4", "cterm": "61", "cterm16": "1" },
-      \ "constantColor": { "gui": "#86dbfd", "cterm": "117", "cterm16": "1" },
+      \ "constantColor": { "gui": "#48ffd6", "cterm": "86", "cterm16": "1" },
       \ "foregroundColorEditor": { "gui": "#F8F8F2", "cterm": "255", "cterm16": "1" },
       \ "htmlTagColor": { "gui": "#a28a92", "cterm": "246", "cterm16": "1" },
       \ "editorAccentColor": { "gui": "#578CDA", "cterm": "68", "cterm16": "1" },

--- a/autoload/astolfo.vim
+++ b/autoload/astolfo.vim
@@ -29,9 +29,9 @@ let s:colors = {
       \ "lineNumberColor": { "gui": "#8e856e", "cterm": "101", "cterm16": "1" },
       \ "lightEditorColor": { "gui": "#1e201d", "cterm": "234", "cterm16": "1" },
       \ "searchForeground": { "gui": "#fbfbfb", "cterm": "231", "cterm16": "1" },
-      \ "searchBackground": { "gui": "#65395B", "cterm": "240", "cterm16": "1" },
+      \ "searchBackground": { "gui": "#753B78", "cterm": "243", "cterm16": "1" },
       \ "selectionForeground": { "gui": "#fbfbfb", "cterm": "231", "cterm16": "1" },
-      \ "selectionBackground": { "gui": "#391717", "cterm": "234", "cterm16": "1" },
+      \ "selectionBackground": { "gui": "#501C1C", "cterm": "234", "cterm16": "1" },
       \ "foldedTextBackground": { "gui": "#211D1E", "cterm": "234", "cterm16": "1" },
       \ "stringColor": { "gui": "#cd5257", "cterm": "167", "cterm16": "1" }
       \}

--- a/autoload/beatrice.vim
+++ b/autoload/beatrice.vim
@@ -28,10 +28,10 @@ let s:colors = {
       \ "terminalAnsiYellow": { "gui": "#db974d", "cterm": "173", "cterm16": "1" },
       \ "lineNumberColor": { "gui": "#aaaaaa", "cterm": "248", "cterm16": "1" },
       \ "lightEditorColor": { "gui": "#ffe0ea", "cterm": "224", "cterm16": "1" },
-      \ "searchForeground": { "gui": "#ffffff", "cterm": "231", "cterm16": "1" },
+      \ "searchForeground": { "gui": "#232323", "cterm": "235", "cterm16": "1" },
       \ "searchBackground": { "gui": "#dc99bb", "cterm": "175", "cterm16": "1" },
-      \ "selectionForeground": { "gui": "#ffffff", "cterm": "231", "cterm16": "1" },
-      \ "selectionBackground": { "gui": "#dc99bb", "cterm": "175", "cterm16": "1" },
+      \ "selectionForeground": { "gui": "#f049da", "cterm": "206", "cterm16": "1" },
+      \ "selectionBackground": { "gui": "#fcc9f2", "cterm": "225", "cterm16": "1" },
       \ "foldedTextBackground": { "gui": "#F1E5FA", "cterm": "255", "cterm16": "1" },
       \ "stringColor": { "gui": "#DC872E", "cterm": "172", "cterm16": "1" }
       \}

--- a/autoload/christmas_chocola.vim
+++ b/autoload/christmas_chocola.vim
@@ -1,25 +1,25 @@
 
 
 let s:colors = {
-      \ "comments": { "gui": "#72A174", "cterm": "243", "cterm16": "1" },
+      \ "comments": { "gui": "#A26673", "cterm": "131", "cterm16": "1" },
       \ "constantColor": { "gui": "#96b7fb", "cterm": "111", "cterm16": "1" },
       \ "foregroundColorEditor": { "gui": "#F8F8F2", "cterm": "255", "cterm16": "1" },
-      \ "htmlTagColor": { "gui": "#ff6b75", "cterm": "204", "cterm16": "1" },
-      \ "editorAccentColor": { "gui": "#77EA6E", "cterm": "113", "cterm16": "1" },
+      \ "htmlTagColor": { "gui": "#DC3A3A", "cterm": "167", "cterm16": "1" },
+      \ "editorAccentColor": { "gui": "#f16e7f", "cterm": "204", "cterm16": "1" },
       \ "classNameColor": { "gui": "#f689f6", "cterm": "213", "cterm16": "1" },
-      \ "keywordColor": { "gui": "#EF354B", "cterm": "203", "cterm16": "1" },
-      \ "keyColor": { "gui": "#48eae4", "cterm": "80", "cterm16": "1" },
+      \ "keywordColor": { "gui": "#F63E54", "cterm": "203", "cterm16": "1" },
+      \ "keyColor": { "gui": "#77EA6E", "cterm": "113", "cterm16": "1" },
       \ "errorColor": { "gui": "#ff1212", "cterm": "196", "cterm16": "1" },
       \ "headerColor": { "gui": "#37131b", "cterm": "234", "cterm16": "1" },
       \ "accentColor": { "gui": "#239324", "cterm": "28", "cterm16": "1" },
-      \ "infoForeground": { "gui": "#46b462", "cterm": "71", "cterm16": "1" },
-      \ "unusedColor": { "gui": "#4e674d", "cterm": "239", "cterm16": "1" },
+      \ "infoForeground": { "gui": "#56b36f", "cterm": "71", "cterm16": "1" },
+      \ "unusedColor": { "gui": "#674d54", "cterm": "240", "cterm16": "1" },
       \ "diffModified": { "gui": "#164150", "cterm": "238", "cterm16": "1" },
       \ "diffInserted": { "gui": "#113B1B", "cterm": "234", "cterm16": "1" },
       \ "diffDeleted": { "gui": "#263631", "cterm": "236", "cterm16": "1" },
       \ "codeBlock": { "gui": "#342422", "cterm": "235", "cterm16": "1" },
-      \ "caretRow": { "gui": "#1e3828", "cterm": "235", "cterm16": "1" },
-      \ "textEditorBackground": { "gui": "#172b1f", "cterm": "234", "cterm16": "1" },
+      \ "caretRow": { "gui": "#4f1b27", "cterm": "235", "cterm16": "1" },
+      \ "textEditorBackground": { "gui": "#3a141d", "cterm": "234", "cterm16": "1" },
       \ "terminalAnsiRed": { "gui": "#E356A7", "cterm": "169", "cterm16": "1" },
       \ "terminalAnsiBlue": { "gui": "#9B6BDF", "cterm": "98", "cterm16": "1" },
       \ "terminalAnsiCyan": { "gui": "#75D7EC", "cterm": "117", "cterm16": "1" },
@@ -27,13 +27,13 @@ let s:colors = {
       \ "terminalAnsiMagenta": { "gui": "#E64747", "cterm": "167", "cterm16": "1" },
       \ "terminalAnsiYellow": { "gui": "#EFA554", "cterm": "215", "cterm16": "1" },
       \ "lineNumberColor": { "gui": "#6d816c", "cterm": "242", "cterm16": "1" },
-      \ "lightEditorColor": { "gui": "#1b3324", "cterm": "235", "cterm16": "1" },
+      \ "lightEditorColor": { "gui": "#471823", "cterm": "235", "cterm16": "1" },
       \ "searchForeground": { "gui": "#fefefe", "cterm": "231", "cterm16": "1" },
       \ "searchBackground": { "gui": "#710E1B", "cterm": "52", "cterm16": "1" },
       \ "selectionForeground": { "gui": "#fefefe", "cterm": "231", "cterm16": "1" },
       \ "selectionBackground": { "gui": "#1f422d", "cterm": "236", "cterm16": "1" },
-      \ "foldedTextBackground": { "gui": "#22402e", "cterm": "236", "cterm16": "1" },
-      \ "stringColor": { "gui": "#FDBAAE", "cterm": "217", "cterm16": "1" }
+      \ "foldedTextBackground": { "gui": "#491925", "cterm": "235", "cterm16": "1" },
+      \ "stringColor": { "gui": "#C2FFAA", "cterm": "157", "cterm16": "1" }
       \}
 
 function! christmas_chocola#GetColors()

--- a/autoload/emilia_dark.vim
+++ b/autoload/emilia_dark.vim
@@ -2,13 +2,13 @@
 
 let s:colors = {
       \ "comments": { "gui": "#9277a7", "cterm": "103", "cterm16": "1" },
-      \ "constantColor": { "gui": "#86dbfd", "cterm": "117", "cterm16": "1" },
+      \ "constantColor": { "gui": "#FFB9A7", "cterm": "217", "cterm16": "1" },
       \ "foregroundColorEditor": { "gui": "#F8F8F2", "cterm": "255", "cterm16": "1" },
-      \ "htmlTagColor": { "gui": "#bca3aa", "cterm": "248", "cterm16": "1" },
-      \ "editorAccentColor": { "gui": "#BC60CB", "cterm": "134", "cterm16": "1" },
+      \ "htmlTagColor": { "gui": "#BF98F1", "cterm": "141", "cterm16": "1" },
+      \ "editorAccentColor": { "gui": "#AE7BFF", "cterm": "141", "cterm16": "1" },
       \ "classNameColor": { "gui": "#FF9CD6", "cterm": "218", "cterm16": "1" },
-      \ "keywordColor": { "gui": "#e049b0", "cterm": "169", "cterm16": "1" },
-      \ "keyColor": { "gui": "#a475ef", "cterm": "141", "cterm16": "1" },
+      \ "keywordColor": { "gui": "#EF69C3", "cterm": "205", "cterm16": "1" },
+      \ "keyColor": { "gui": "#C1A2F8", "cterm": "147", "cterm16": "1" },
       \ "errorColor": { "gui": "#ff5555", "cterm": "203", "cterm16": "1" },
       \ "headerColor": { "gui": "#4c2e5c", "cterm": "239", "cterm16": "1" },
       \ "accentColor": { "gui": "#a53ba0", "cterm": "133", "cterm16": "1" },
@@ -31,7 +31,7 @@ let s:colors = {
       \ "searchForeground": { "gui": "#e7e5f3", "cterm": "254", "cterm16": "1" },
       \ "searchBackground": { "gui": "#7749b2", "cterm": "97", "cterm16": "1" },
       \ "selectionForeground": { "gui": "#d29eff", "cterm": "183", "cterm16": "1" },
-      \ "selectionBackground": { "gui": "#51256d", "cterm": "53", "cterm16": "1" },
+      \ "selectionBackground": { "gui": "#5C3378", "cterm": "60", "cterm16": "1" },
       \ "foldedTextBackground": { "gui": "#402a54", "cterm": "238", "cterm16": "1" },
       \ "stringColor": { "gui": "#FDEFA2", "cterm": "229", "cterm16": "1" }
       \}

--- a/autoload/hatsune_miku.vim
+++ b/autoload/hatsune_miku.vim
@@ -5,10 +5,10 @@ let s:colors = {
       \ "constantColor": { "gui": "#86dbfd", "cterm": "117", "cterm16": "1" },
       \ "foregroundColorEditor": { "gui": "#F8F8F2", "cterm": "255", "cterm16": "1" },
       \ "htmlTagColor": { "gui": "#60a498", "cterm": "72", "cterm16": "1" },
-      \ "editorAccentColor": { "gui": "#ff69df", "cterm": "206", "cterm16": "1" },
-      \ "classNameColor": { "gui": "#aae2f2", "cterm": "153", "cterm16": "1" },
-      \ "keywordColor": { "gui": "#988F9A", "cterm": "246", "cterm16": "1" },
-      \ "keyColor": { "gui": "#68f3e7", "cterm": "86", "cterm16": "1" },
+      \ "editorAccentColor": { "gui": "#FF9CEA", "cterm": "218", "cterm16": "1" },
+      \ "classNameColor": { "gui": "#F6E9CB", "cterm": "224", "cterm16": "1" },
+      \ "keywordColor": { "gui": "#7BF8E1", "cterm": "122", "cterm16": "1" },
+      \ "keyColor": { "gui": "#95C8FA", "cterm": "117", "cterm16": "1" },
       \ "errorColor": { "gui": "#ff5555", "cterm": "203", "cterm16": "1" },
       \ "headerColor": { "gui": "#2c3333", "cterm": "236", "cterm16": "1" },
       \ "accentColor": { "gui": "#53b0b4", "cterm": "73", "cterm16": "1" },
@@ -33,7 +33,7 @@ let s:colors = {
       \ "selectionForeground": { "gui": "#fbfbfb", "cterm": "231", "cterm16": "1" },
       \ "selectionBackground": { "gui": "#4c7a76", "cterm": "243", "cterm16": "1" },
       \ "foldedTextBackground": { "gui": "#273431", "cterm": "236", "cterm16": "1" },
-      \ "stringColor": { "gui": "#F6E9CB", "cterm": "224", "cterm16": "1" }
+      \ "stringColor": { "gui": "#B5F6BA", "cterm": "157", "cterm16": "1" }
       \}
 
 function! hatsune_miku#GetColors()

--- a/autoload/mioda_ibuki_dark.vim
+++ b/autoload/mioda_ibuki_dark.vim
@@ -4,7 +4,7 @@ let s:colors = {
       \ "comments": { "gui": "#6272a4", "cterm": "61", "cterm16": "1" },
       \ "constantColor": { "gui": "#86dbfd", "cterm": "117", "cterm16": "1" },
       \ "foregroundColorEditor": { "gui": "#F8F8F2", "cterm": "255", "cterm16": "1" },
-      \ "htmlTagColor": { "gui": "#a28a92", "cterm": "246", "cterm16": "1" },
+      \ "htmlTagColor": { "gui": "#93B6F5", "cterm": "111", "cterm16": "1" },
       \ "editorAccentColor": { "gui": "#ff69df", "cterm": "206", "cterm16": "1" },
       \ "classNameColor": { "gui": "#8daeef", "cterm": "111", "cterm16": "1" },
       \ "keywordColor": { "gui": "#8b8b8b", "cterm": "245", "cterm16": "1" },

--- a/autoload/misaka_mikoto.vim
+++ b/autoload/misaka_mikoto.vim
@@ -1,0 +1,41 @@
+
+
+let s:colors = {
+      \ "comments": { "gui": "#5c6c9e", "cterm": "61", "cterm16": "1" },
+      \ "constantColor": { "gui": "#EA7797", "cterm": "174", "cterm16": "1" },
+      \ "foregroundColorEditor": { "gui": "#F8F8F2", "cterm": "255", "cterm16": "1" },
+      \ "htmlTagColor": { "gui": "#7286F5", "cterm": "69", "cterm16": "1" },
+      \ "editorAccentColor": { "gui": "#f3b085", "cterm": "216", "cterm16": "1" },
+      \ "classNameColor": { "gui": "#8BEF85", "cterm": "120", "cterm16": "1" },
+      \ "keywordColor": { "gui": "#57e1ee", "cterm": "81", "cterm16": "1" },
+      \ "keyColor": { "gui": "#FFE35C", "cterm": "221", "cterm16": "1" },
+      \ "errorColor": { "gui": "#ff2525", "cterm": "196", "cterm16": "1" },
+      \ "headerColor": { "gui": "#0b1633", "cterm": "233", "cterm16": "1" },
+      \ "accentColor": { "gui": "#3eb7e5", "cterm": "74", "cterm16": "1" },
+      \ "infoForeground": { "gui": "#70bfbc", "cterm": "73", "cterm16": "1" },
+      \ "unusedColor": { "gui": "#4e565e", "cterm": "240", "cterm16": "1" },
+      \ "diffModified": { "gui": "#183059", "cterm": "236", "cterm16": "1" },
+      \ "diffInserted": { "gui": "#122C12", "cterm": "233", "cterm16": "1" },
+      \ "diffDeleted": { "gui": "#232C3E", "cterm": "236", "cterm16": "1" },
+      \ "codeBlock": { "gui": "#0a2458", "cterm": "17", "cterm16": "1" },
+      \ "caretRow": { "gui": "#112358", "cterm": "17", "cterm16": "1" },
+      \ "textEditorBackground": { "gui": "#0b173a", "cterm": "233", "cterm16": "1" },
+      \ "terminalAnsiRed": { "gui": "#E356A7", "cterm": "169", "cterm16": "1" },
+      \ "terminalAnsiBlue": { "gui": "#9B6BDF", "cterm": "98", "cterm16": "1" },
+      \ "terminalAnsiCyan": { "gui": "#75D7EC", "cterm": "117", "cterm16": "1" },
+      \ "terminalAnsiGreen": { "gui": "#42E66C", "cterm": "77", "cterm16": "1" },
+      \ "terminalAnsiMagenta": { "gui": "#E64747", "cterm": "167", "cterm16": "1" },
+      \ "terminalAnsiYellow": { "gui": "#EFA554", "cterm": "215", "cterm16": "1" },
+      \ "lineNumberColor": { "gui": "#5d6680", "cterm": "60", "cterm16": "1" },
+      \ "lightEditorColor": { "gui": "#0f1e4c", "cterm": "234", "cterm16": "1" },
+      \ "searchForeground": { "gui": "#fefefe", "cterm": "231", "cterm16": "1" },
+      \ "searchBackground": { "gui": "#127B1B", "cterm": "28", "cterm16": "1" },
+      \ "selectionForeground": { "gui": "#fbfbfb", "cterm": "231", "cterm16": "1" },
+      \ "selectionBackground": { "gui": "#05649c", "cterm": "25", "cterm16": "1" },
+      \ "foldedTextBackground": { "gui": "#16295e", "cterm": "17", "cterm16": "1" },
+      \ "stringColor": { "gui": "#A2EEFC", "cterm": "159", "cterm16": "1" }
+      \}
+
+function! misaka_mikoto#GetColors()
+  return s:colors
+endfunction

--- a/autoload/nadeshiko.vim
+++ b/autoload/nadeshiko.vim
@@ -1,0 +1,41 @@
+
+
+let s:colors = {
+      \ "comments": { "gui": "#80687f", "cterm": "96", "cterm16": "1" },
+      \ "constantColor": { "gui": "#AE9AFF", "cterm": "141", "cterm16": "1" },
+      \ "foregroundColorEditor": { "gui": "#F8F8F2", "cterm": "255", "cterm16": "1" },
+      \ "htmlTagColor": { "gui": "#ea8f73", "cterm": "173", "cterm16": "1" },
+      \ "editorAccentColor": { "gui": "#ff8bfd", "cterm": "213", "cterm16": "1" },
+      \ "classNameColor": { "gui": "#61ead9", "cterm": "80", "cterm16": "1" },
+      \ "keywordColor": { "gui": "#ec9cb2", "cterm": "217", "cterm16": "1" },
+      \ "keyColor": { "gui": "#61c1ea", "cterm": "74", "cterm16": "1" },
+      \ "errorColor": { "gui": "#ff5555", "cterm": "203", "cterm16": "1" },
+      \ "headerColor": { "gui": "#2f2128", "cterm": "235", "cterm16": "1" },
+      \ "accentColor": { "gui": "#78c6d0", "cterm": "116", "cterm16": "1" },
+      \ "infoForeground": { "gui": "#7ea5c1", "cterm": "109", "cterm16": "1" },
+      \ "unusedColor": { "gui": "#5b545c", "cterm": "240", "cterm16": "1" },
+      \ "diffModified": { "gui": "#253F4C", "cterm": "237", "cterm16": "1" },
+      \ "diffInserted": { "gui": "#223B28", "cterm": "235", "cterm16": "1" },
+      \ "diffDeleted": { "gui": "#343037", "cterm": "236", "cterm16": "1" },
+      \ "codeBlock": { "gui": "#332625", "cterm": "235", "cterm16": "1" },
+      \ "caretRow": { "gui": "#392831", "cterm": "236", "cterm16": "1" },
+      \ "textEditorBackground": { "gui": "#2c1f26", "cterm": "235", "cterm16": "1" },
+      \ "terminalAnsiRed": { "gui": "#E356A7", "cterm": "169", "cterm16": "1" },
+      \ "terminalAnsiBlue": { "gui": "#9B6BDF", "cterm": "98", "cterm16": "1" },
+      \ "terminalAnsiCyan": { "gui": "#75D7EC", "cterm": "117", "cterm16": "1" },
+      \ "terminalAnsiGreen": { "gui": "#42E66C", "cterm": "77", "cterm16": "1" },
+      \ "terminalAnsiMagenta": { "gui": "#E64747", "cterm": "167", "cterm16": "1" },
+      \ "terminalAnsiYellow": { "gui": "#EFA554", "cterm": "215", "cterm16": "1" },
+      \ "lineNumberColor": { "gui": "#6a5a6c", "cterm": "242", "cterm16": "1" },
+      \ "lightEditorColor": { "gui": "#34242d", "cterm": "236", "cterm16": "1" },
+      \ "searchForeground": { "gui": "#fbfbfb", "cterm": "231", "cterm16": "1" },
+      \ "searchBackground": { "gui": "#195A80", "cterm": "24", "cterm16": "1" },
+      \ "selectionForeground": { "gui": "#fbfbfb", "cterm": "231", "cterm16": "1" },
+      \ "selectionBackground": { "gui": "#553854", "cterm": "239", "cterm16": "1" },
+      \ "foldedTextBackground": { "gui": "#392831", "cterm": "236", "cterm16": "1" },
+      \ "stringColor": { "gui": "#F6E9CB", "cterm": "224", "cterm16": "1" }
+      \}
+
+function! nadeshiko#GetColors()
+  return s:colors
+endfunction

--- a/autoload/natsuki_light.vim
+++ b/autoload/natsuki_light.vim
@@ -30,8 +30,8 @@ let s:colors = {
       \ "lightEditorColor": { "gui": "#ffe0ea", "cterm": "224", "cterm16": "1" },
       \ "searchForeground": { "gui": "#ffffff", "cterm": "231", "cterm16": "1" },
       \ "searchBackground": { "gui": "#dc99bb", "cterm": "175", "cterm16": "1" },
-      \ "selectionForeground": { "gui": "#ffffff", "cterm": "231", "cterm16": "1" },
-      \ "selectionBackground": { "gui": "#dc99bb", "cterm": "175", "cterm16": "1" },
+      \ "selectionForeground": { "gui": "#f049da", "cterm": "206", "cterm16": "1" },
+      \ "selectionBackground": { "gui": "#fcc9f2", "cterm": "225", "cterm16": "1" },
       \ "foldedTextBackground": { "gui": "#F1E5FA", "cterm": "255", "cterm16": "1" },
       \ "stringColor": { "gui": "#DC872E", "cterm": "172", "cterm16": "1" }
       \}

--- a/autoload/ram.vim
+++ b/autoload/ram.vim
@@ -2,24 +2,24 @@
 
 let s:colors = {
       \ "comments": { "gui": "#987fa5", "cterm": "103", "cterm16": "1" },
-      \ "constantColor": { "gui": "#86dbfd", "cterm": "117", "cterm16": "1" },
+      \ "constantColor": { "gui": "#85FFEF", "cterm": "123", "cterm16": "1" },
       \ "foregroundColorEditor": { "gui": "#F8F8F2", "cterm": "255", "cterm16": "1" },
       \ "htmlTagColor": { "gui": "#C84EB8", "cterm": "169", "cterm16": "1" },
-      \ "editorAccentColor": { "gui": "#a87ff8", "cterm": "141", "cterm16": "1" },
-      \ "classNameColor": { "gui": "#EF9FD8", "cterm": "218", "cterm16": "1" },
-      \ "keywordColor": { "gui": "#988F9A", "cterm": "246", "cterm16": "1" },
-      \ "keyColor": { "gui": "#F375C8", "cterm": "212", "cterm16": "1" },
+      \ "editorAccentColor": { "gui": "#e88def", "cterm": "177", "cterm16": "1" },
+      \ "classNameColor": { "gui": "#FBFF90", "cterm": "228", "cterm16": "1" },
+      \ "keywordColor": { "gui": "#ef57bf", "cterm": "205", "cterm16": "1" },
+      \ "keyColor": { "gui": "#986DEA", "cterm": "98", "cterm16": "1" },
       \ "errorColor": { "gui": "#ff5555", "cterm": "203", "cterm16": "1" },
-      \ "headerColor": { "gui": "#322c33", "cterm": "236", "cterm16": "1" },
+      \ "headerColor": { "gui": "#2b252b", "cterm": "235", "cterm16": "1" },
       \ "accentColor": { "gui": "#e594bf", "cterm": "175", "cterm16": "1" },
       \ "infoForeground": { "gui": "#ab7b9d", "cterm": "139", "cterm16": "1" },
       \ "unusedColor": { "gui": "#72737A", "cterm": "243", "cterm16": "1" },
       \ "diffModified": { "gui": "#203952", "cterm": "237", "cterm16": "1" },
       \ "diffInserted": { "gui": "#1B3B1C", "cterm": "234", "cterm16": "1" },
       \ "diffDeleted": { "gui": "#3B393A", "cterm": "237", "cterm16": "1" },
-      \ "codeBlock": { "gui": "#322a32", "cterm": "236", "cterm16": "1" },
+      \ "codeBlock": { "gui": "#42283e", "cterm": "237", "cterm16": "1" },
       \ "caretRow": { "gui": "#353139", "cterm": "236", "cterm16": "1" },
-      \ "textEditorBackground": { "gui": "#342f36", "cterm": "236", "cterm16": "1" },
+      \ "textEditorBackground": { "gui": "#342c34", "cterm": "236", "cterm16": "1" },
       \ "terminalAnsiRed": { "gui": "#E356A7", "cterm": "169", "cterm16": "1" },
       \ "terminalAnsiBlue": { "gui": "#9B6BDF", "cterm": "98", "cterm16": "1" },
       \ "terminalAnsiCyan": { "gui": "#75D7EC", "cterm": "117", "cterm16": "1" },
@@ -33,7 +33,7 @@ let s:colors = {
       \ "selectionForeground": { "gui": "#fbfbfb", "cterm": "231", "cterm16": "1" },
       \ "selectionBackground": { "gui": "#7a546f", "cterm": "95", "cterm16": "1" },
       \ "foldedTextBackground": { "gui": "#322634", "cterm": "236", "cterm16": "1" },
-      \ "stringColor": { "gui": "#f4fa8c", "cterm": "228", "cterm16": "1" }
+      \ "stringColor": { "gui": "#a1e9ff", "cterm": "153", "cterm16": "1" }
       \}
 
 function! ram#GetColors()

--- a/autoload/raphtalia.vim
+++ b/autoload/raphtalia.vim
@@ -1,0 +1,41 @@
+
+
+let s:colors = {
+      \ "comments": { "gui": "#807571", "cterm": "243", "cterm16": "1" },
+      \ "constantColor": { "gui": "#8097e3", "cterm": "104", "cterm16": "1" },
+      \ "foregroundColorEditor": { "gui": "#F8F8F2", "cterm": "255", "cterm16": "1" },
+      \ "htmlTagColor": { "gui": "#d75e88", "cterm": "168", "cterm16": "1" },
+      \ "editorAccentColor": { "gui": "#4fe1a9", "cterm": "79", "cterm16": "1" },
+      \ "classNameColor": { "gui": "#FFD448", "cterm": "221", "cterm16": "1" },
+      \ "keywordColor": { "gui": "#f19992", "cterm": "210", "cterm16": "1" },
+      \ "keyColor": { "gui": "#fd9144", "cterm": "209", "cterm16": "1" },
+      \ "errorColor": { "gui": "#ff2525", "cterm": "196", "cterm16": "1" },
+      \ "headerColor": { "gui": "#1c140f", "cterm": "233", "cterm16": "1" },
+      \ "accentColor": { "gui": "#823a3b", "cterm": "237", "cterm16": "1" },
+      \ "infoForeground": { "gui": "#bfb38c", "cterm": "144", "cterm16": "1" },
+      \ "unusedColor": { "gui": "#606867", "cterm": "241", "cterm16": "1" },
+      \ "diffModified": { "gui": "#1B3A47", "cterm": "237", "cterm16": "1" },
+      \ "diffInserted": { "gui": "#152F1A", "cterm": "234", "cterm16": "1" },
+      \ "diffDeleted": { "gui": "#282621", "cterm": "235", "cterm16": "1" },
+      \ "codeBlock": { "gui": "#2c1e12", "cterm": "234", "cterm16": "1" },
+      \ "caretRow": { "gui": "#2b2016", "cterm": "234", "cterm16": "1" },
+      \ "textEditorBackground": { "gui": "#1e1710", "cterm": "233", "cterm16": "1" },
+      \ "terminalAnsiRed": { "gui": "#E356A7", "cterm": "169", "cterm16": "1" },
+      \ "terminalAnsiBlue": { "gui": "#9B6BDF", "cterm": "98", "cterm16": "1" },
+      \ "terminalAnsiCyan": { "gui": "#75D7EC", "cterm": "117", "cterm16": "1" },
+      \ "terminalAnsiGreen": { "gui": "#42E66C", "cterm": "77", "cterm16": "1" },
+      \ "terminalAnsiMagenta": { "gui": "#E64747", "cterm": "167", "cterm16": "1" },
+      \ "terminalAnsiYellow": { "gui": "#EFA554", "cterm": "215", "cterm16": "1" },
+      \ "lineNumberColor": { "gui": "#6c5f55", "cterm": "59", "cterm16": "1" },
+      \ "lightEditorColor": { "gui": "#261c14", "cterm": "234", "cterm16": "1" },
+      \ "searchForeground": { "gui": "#fbfbfb", "cterm": "231", "cterm16": "1" },
+      \ "searchBackground": { "gui": "#2A5F1E", "cterm": "235", "cterm16": "1" },
+      \ "selectionForeground": { "gui": "#fbfbfb", "cterm": "231", "cterm16": "1" },
+      \ "selectionBackground": { "gui": "#5c3915", "cterm": "58", "cterm16": "1" },
+      \ "foldedTextBackground": { "gui": "#2d2318", "cterm": "235", "cterm16": "1" },
+      \ "stringColor": { "gui": "#FDC78C", "cterm": "222", "cterm16": "1" }
+      \}
+
+function! raphtalia#GetColors()
+  return s:colors
+endfunction

--- a/autoload/rem.vim
+++ b/autoload/rem.vim
@@ -1,25 +1,25 @@
 
 
 let s:colors = {
-      \ "comments": { "gui": "#6272a4", "cterm": "61", "cterm16": "1" },
-      \ "constantColor": { "gui": "#86dbfd", "cterm": "117", "cterm16": "1" },
+      \ "comments": { "gui": "#5C6D80", "cterm": "60", "cterm16": "1" },
+      \ "constantColor": { "gui": "#85FFEF", "cterm": "123", "cterm16": "1" },
       \ "foregroundColorEditor": { "gui": "#F8F8F2", "cterm": "255", "cterm16": "1" },
       \ "htmlTagColor": { "gui": "#4E86C8", "cterm": "68", "cterm16": "1" },
-      \ "editorAccentColor": { "gui": "#a87ff8", "cterm": "141", "cterm16": "1" },
-      \ "classNameColor": { "gui": "#8dc6ef", "cterm": "117", "cterm16": "1" },
-      \ "keywordColor": { "gui": "#988F9A", "cterm": "246", "cterm16": "1" },
-      \ "keyColor": { "gui": "#6893f3", "cterm": "69", "cterm16": "1" },
+      \ "editorAccentColor": { "gui": "#8dc6ef", "cterm": "117", "cterm16": "1" },
+      \ "classNameColor": { "gui": "#FBFF90", "cterm": "228", "cterm16": "1" },
+      \ "keywordColor": { "gui": "#6893f3", "cterm": "69", "cterm16": "1" },
+      \ "keyColor": { "gui": "#986DEA", "cterm": "98", "cterm16": "1" },
       \ "errorColor": { "gui": "#ff5555", "cterm": "203", "cterm16": "1" },
-      \ "headerColor": { "gui": "#2c2d33", "cterm": "236", "cterm16": "1" },
+      \ "headerColor": { "gui": "#25262b", "cterm": "235", "cterm16": "1" },
       \ "accentColor": { "gui": "#578CDA", "cterm": "68", "cterm16": "1" },
       \ "infoForeground": { "gui": "#7b8bab", "cterm": "103", "cterm16": "1" },
       \ "unusedColor": { "gui": "#72737A", "cterm": "243", "cterm16": "1" },
       \ "diffModified": { "gui": "#203952", "cterm": "237", "cterm16": "1" },
       \ "diffInserted": { "gui": "#1B3B1C", "cterm": "234", "cterm16": "1" },
       \ "diffDeleted": { "gui": "#36393B", "cterm": "237", "cterm16": "1" },
-      \ "codeBlock": { "gui": "#2b2c32", "cterm": "236", "cterm16": "1" },
+      \ "codeBlock": { "gui": "#293342", "cterm": "236", "cterm16": "1" },
       \ "caretRow": { "gui": "#313439", "cterm": "236", "cterm16": "1" },
-      \ "textEditorBackground": { "gui": "#2f3036", "cterm": "236", "cterm16": "1" },
+      \ "textEditorBackground": { "gui": "#2c2d34", "cterm": "236", "cterm16": "1" },
       \ "terminalAnsiRed": { "gui": "#E356A7", "cterm": "169", "cterm16": "1" },
       \ "terminalAnsiBlue": { "gui": "#9B6BDF", "cterm": "98", "cterm16": "1" },
       \ "terminalAnsiCyan": { "gui": "#75D7EC", "cterm": "117", "cterm16": "1" },
@@ -33,7 +33,7 @@ let s:colors = {
       \ "selectionForeground": { "gui": "#fbfbfb", "cterm": "231", "cterm16": "1" },
       \ "selectionBackground": { "gui": "#4C637A", "cterm": "60", "cterm16": "1" },
       \ "foldedTextBackground": { "gui": "#272e34", "cterm": "236", "cterm16": "1" },
-      \ "stringColor": { "gui": "#f4fa8c", "cterm": "228", "cterm16": "1" }
+      \ "stringColor": { "gui": "#F0A1FF", "cterm": "219", "cterm16": "1" }
       \}
 
 function! rem#GetColors()

--- a/autoload/takanashi_rikka.vim
+++ b/autoload/takanashi_rikka.vim
@@ -1,0 +1,41 @@
+
+
+let s:colors = {
+      \ "comments": { "gui": "#bf88a4", "cterm": "139", "cterm16": "1" },
+      \ "constantColor": { "gui": "#F9FC88", "cterm": "228", "cterm16": "1" },
+      \ "foregroundColorEditor": { "gui": "#F8F8F2", "cterm": "255", "cterm16": "1" },
+      \ "htmlTagColor": { "gui": "#AC99FC", "cterm": "141", "cterm16": "1" },
+      \ "editorAccentColor": { "gui": "#65CDFA", "cterm": "81", "cterm16": "1" },
+      \ "classNameColor": { "gui": "#67F5C4", "cterm": "86", "cterm16": "1" },
+      \ "keywordColor": { "gui": "#de4371", "cterm": "167", "cterm16": "1" },
+      \ "keyColor": { "gui": "#8C92FC", "cterm": "105", "cterm16": "1" },
+      \ "errorColor": { "gui": "#ff2525", "cterm": "196", "cterm16": "1" },
+      \ "headerColor": { "gui": "#1d1926", "cterm": "234", "cterm16": "1" },
+      \ "accentColor": { "gui": "#dd2a62", "cterm": "161", "cterm16": "1" },
+      \ "infoForeground": { "gui": "#bd7e99", "cterm": "138", "cterm16": "1" },
+      \ "unusedColor": { "gui": "#5c5157", "cterm": "240", "cterm16": "1" },
+      \ "diffModified": { "gui": "#1B2B4B", "cterm": "235", "cterm16": "1" },
+      \ "diffInserted": { "gui": "#0F2F1D", "cterm": "234", "cterm16": "1" },
+      \ "diffDeleted": { "gui": "#292231", "cterm": "235", "cterm16": "1" },
+      \ "codeBlock": { "gui": "#351929", "cterm": "235", "cterm16": "1" },
+      \ "caretRow": { "gui": "#2b233a", "cterm": "235", "cterm16": "1" },
+      \ "textEditorBackground": { "gui": "#1e1928", "cterm": "234", "cterm16": "1" },
+      \ "terminalAnsiRed": { "gui": "#E356A7", "cterm": "169", "cterm16": "1" },
+      \ "terminalAnsiBlue": { "gui": "#9B6BDF", "cterm": "98", "cterm16": "1" },
+      \ "terminalAnsiCyan": { "gui": "#75D7EC", "cterm": "117", "cterm16": "1" },
+      \ "terminalAnsiGreen": { "gui": "#42E66C", "cterm": "77", "cterm16": "1" },
+      \ "terminalAnsiMagenta": { "gui": "#E64747", "cterm": "167", "cterm16": "1" },
+      \ "terminalAnsiYellow": { "gui": "#EFA554", "cterm": "215", "cterm16": "1" },
+      \ "lineNumberColor": { "gui": "#8e6e7b", "cterm": "96", "cterm16": "1" },
+      \ "lightEditorColor": { "gui": "#261f33", "cterm": "235", "cterm16": "1" },
+      \ "searchForeground": { "gui": "#fbfbfb", "cterm": "231", "cterm16": "1" },
+      \ "searchBackground": { "gui": "#277FA5", "cterm": "31", "cterm16": "1" },
+      \ "selectionForeground": { "gui": "#fbfbfb", "cterm": "231", "cterm16": "1" },
+      \ "selectionBackground": { "gui": "#761d3a", "cterm": "89", "cterm16": "1" },
+      \ "foldedTextBackground": { "gui": "#2b2538", "cterm": "235", "cterm16": "1" },
+      \ "stringColor": { "gui": "#FFB4F8", "cterm": "219", "cterm16": "1" }
+      \}
+
+function! takanashi_rikka#GetColors()
+  return s:colors
+endfunction

--- a/buildSrc/assets/themes/chuunibyou/rikka/dark/rikka.dark.vim.definition.json
+++ b/buildSrc/assets/themes/chuunibyou/rikka/dark/rikka.dark.vim.definition.json
@@ -1,0 +1,7 @@
+{
+  "id": "5412c41d-f76b-4488-85a7-1ae1a63bbfcc",
+  "overrides": {},
+  "laf": {},
+  "syntax": {},
+  "colors": {}
+}

--- a/buildSrc/assets/themes/railgun/mikoto/dark/mikoto.dark.vim.definition.json
+++ b/buildSrc/assets/themes/railgun/mikoto/dark/mikoto.dark.vim.definition.json
@@ -1,0 +1,7 @@
+{
+  "id": "01e61500-862c-41cd-b653-48d2ef7b1882",
+  "overrides": {},
+  "laf": {},
+  "syntax": {},
+  "colors": {}
+}

--- a/buildSrc/assets/themes/shieldHero/raphtalia/dark/raphtalia.dark.vim.definition.json
+++ b/buildSrc/assets/themes/shieldHero/raphtalia/dark/raphtalia.dark.vim.definition.json
@@ -1,0 +1,7 @@
+{
+  "id": "df23dabc-61eb-4559-a504-992786964602",
+  "overrides": {},
+  "laf": {},
+  "syntax": {},
+  "colors": {}
+}

--- a/buildSrc/assets/themes/yuruCamp/nadeshiko/dark/nadeshiko.dark.vim.definition.json
+++ b/buildSrc/assets/themes/yuruCamp/nadeshiko/dark/nadeshiko.dark.vim.definition.json
@@ -1,0 +1,7 @@
+{
+  "id": "d587f5ab-9334-4b7b-a99e-58461719d87b",
+  "overrides": {},
+  "laf": {},
+  "syntax": {},
+  "colors": {}
+}

--- a/buildSrc/package.json
+++ b/buildSrc/package.json
@@ -12,7 +12,7 @@
     "@types/jest": "^26.0.0",
     "@types/lodash": "^4.14.155",
     "copy-webpack-plugin": "^6.0.2",
-    "doki-build-source": "1.8.0",
+    "doki-build-source": "74.1.0",
     "jest": "^26.0.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.1.0",

--- a/buildSrc/yarn.lock
+++ b/buildSrc/yarn.lock
@@ -1841,10 +1841,10 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-doki-build-source@1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/doki-build-source/-/doki-build-source-1.8.0.tgz#30f82942eca97f4091697302e55ff5504a7bf42e"
-  integrity sha512-l7gvHdcptjruHPVe0KB5UgY9lTjtbxC8aqE2ds4+eD78OttjCgUrfJjAVeeY0tF2cp3vZ8+3eUB9EthbuwL3eQ==
+doki-build-source@74.1.0:
+  version "74.1.0"
+  resolved "https://registry.yarnpkg.com/doki-build-source/-/doki-build-source-74.1.0.tgz#2ae6c74273de4cf3021d7a5cdbbfe4369c50439a"
+  integrity sha512-6CitL8Qw9LM9NqTFLNJxe5p7g1yhhE9uSUajRTwXLJisdVtMmjIIdx6Hodcwi1sxi7qBmUBMKd1JF3jlGZ61rQ==
 
 domain-browser@^1.1.1:
   version "1.2.0"

--- a/colors/misaka_mikoto.vim
+++ b/colors/misaka_mikoto.vim
@@ -1,0 +1,311 @@
+if v:version > 580
+  highlight clear
+  if exists('syntax_on')
+    syntax reset
+  endif
+endif
+
+let g:colors_name = 'misaka_mikoto'
+
+set t_Co=256
+
+" Set to "256" for 256-color terminals, or
+" set to "16" to use your terminal emulator's native colors
+" (a 16-color palette for this color scheme is available; see
+" < https://github.com/joshdick/
+" for more information.)
+if !exists("g:misaka_mikoto_termcolors")
+  let g:misaka_mikoto_termcolors = 256
+endif
+
+" Not all terminals support italics properly. If yours does, opt-in.
+if !exists("g:misaka_mikoto_terminal_italics")
+  let g:misaka_mikoto_terminal_italics = 0
+endif
+
+if !(has('termguicolors') && &termguicolors) && !has('gui_running') && &t_Co != 256
+  finish
+endif
+
+" This function is based on one from FlatColor: https://github.com/MaxSt/FlatColor/
+" Which in turn was based on one found in hemisu: https://github.com/noahfrederick/vim-hemisu/
+let s:group_colors = {} " Cache of default highlight group settings, for later reference via `
+function! s:h(group, style, ...)
+  if (a:0 > 0) " Will be true if we got here from 
+    let s:highlight = s:group_colors[a:group]
+    for style_type in ["fg", "bg", "sp"]
+      if (has_key(a:style, style_type))
+        let l:default_style = (has_key(s:highlight, style_type) ? copy(s:highlight[style_type]) : { "cterm16": "NONE", "cterm": "NONE", "gui": "NONE" })
+        let s:highlight[style_type] = extend(l:default_style, a:style[style_type])
+      endif
+    endfor
+    if (has_key(a:style, "gui"))
+      let s:highlight.gui = a:style.gui
+    endif
+  else
+    let s:highlight = a:style
+    let s:group_colors[a:group] = s:highlight " Cache default highlight group settings
+  endif
+
+  if g:misaka_mikoto_terminal_italics == 0
+    if has_key(s:highlight, "cterm") && s:highlight["cterm"] == "italic"
+      unlet s:highlight.cterm
+    endif
+    if has_key(s:highlight, "gui") && s:highlight["gui"] == "italic"
+      unlet s:highlight.gui
+    endif
+  endif
+
+  if g:misaka_mikoto_termcolors == 16
+    let l:ctermfg = (has_key(s:highlight, "fg") ? s:highlight.fg.cterm16 : "NONE")
+    let l:ctermbg = (has_key(s:highlight, "bg") ? s:highlight.bg.cterm16 : "NONE")
+  else
+    let l:ctermfg = (has_key(s:highlight, "fg") ? s:highlight.fg.cterm : "NONE")
+    let l:ctermbg = (has_key(s:highlight, "bg") ? s:highlight.bg.cterm : "NONE")
+  endif
+
+  execute "highlight" a:group
+    \ "guifg="   (has_key(s:highlight, "fg")    ? s:highlight.fg.gui   : "NONE")
+    \ "guibg="   (has_key(s:highlight, "bg")    ? s:highlight.bg.gui   : "NONE")
+    \ "guisp="   (has_key(s:highlight, "sp")    ? s:highlight.sp.gui   : "NONE")
+    \ "gui="     (has_key(s:highlight, "gui")   ? s:highlight.gui      : "NONE")
+    \ "ctermfg=" . l:ctermfg
+    \ "ctermbg=" . l:ctermbg
+    \ "cterm="   (has_key(s:highlight, "cterm") ? s:highlight.cterm    : "NONE")
+endfunction
+
+let s:colors = misaka_mikoto#GetColors() " Autoloaded from the specific color theme
+
+" Global colors
+call s:h("Comment", { "fg": s:colors.comments, "gui": "italic", "cterm": "italic" })
+call s:h("String", {"fg": s:colors.stringColor})
+call s:h("Constant", {"fg": s:colors.constantColor})
+call s:h("Identifier", {"fg": s:colors.foregroundColorEditor})
+call s:h("Function", {"fg": s:colors.classNameColor})
+call s:h("Underlined", {"fg": s:colors.keyColor})
+call s:h("Type", {"fg": s:colors.keyColor})
+call s:h("PreProc", {"fg": s:colors.keyColor})
+call s:h("StorageClass", {"fg": s:colors.keywordColor})
+call s:h("Keyword", {"fg": s:colors.keywordColor})
+call s:h("Statement", {"fg": s:colors.keywordColor})
+call s:h("SpecialChar", {"fg": s:colors.keyColor})
+call s:h("SpecialComment", {"fg": s:colors.keyColor})
+call s:h("Special", {"fg": s:colors.keyColor})
+call s:h("Operator", {"fg": s:colors.htmlTagColor})
+call s:h("foldBraces", {"fg": s:colors.foregroundColorEditor})
+call s:h("Error", {"fg": s:colors.errorColor, "gui": "underline", "cterm":"underline"})
+
+" VIM Stuff
+call s:h("Cursor", {"bg": s:colors.accentColor})
+call s:h("ColorColumn", {"bg": s:colors.caretRow})
+call s:h("CursorColumn", {"bg": s:colors.caretRow})
+call s:h("CursorLine", {"bg": s:colors.caretRow})
+call s:h("DiffAdd", {"bg": s:colors.diffInserted})
+call s:h("DiffChange", {"bg": s:colors.diffModified})
+call s:h("DiffDelete", {"bg": s:colors.diffDeleted})
+call s:h("DiffText", {"bg": s:colors.diffModified})
+call s:h("LineNr", {"fg": s:colors.lineNumberColor})
+call s:h("Pmenu", {"fg": s:colors.foregroundColorEditor})
+call s:h("Normal", {"fg": s:colors.foregroundColorEditor})
+call s:h("NonText", {"fg": s:colors.comments})
+call s:h("ModeMsg", {"fg": s:colors.infoForeground})
+call s:h("PmenuSbar", {"bg": s:colors.lightEditorColor})
+call s:h("PmenuThumb", {"bg": s:colors.accentColor})
+call s:h("ErrorMsg", {"bg": s:colors.errorColor})
+call s:h("VertSplit", {"fg": s:colors.lineNumberColor, "bg": s:colors.lightEditorColor})
+call s:h("StatusLine", {"fg": s:colors.foregroundColorEditor, "bg": s:colors.lightEditorColor})
+call s:h("StatusLineNc", {"fg": s:colors.lineNumberColor, "bg": s:colors.lightEditorColor})
+call s:h("Search", {"fg": s:colors.searchForeground, "bg": s:colors.searchBackground})
+call s:h("IncSearch", {"fg": s:colors.searchForeground, "bg": s:colors.searchBackground})
+call s:h("MatchParen", {"fg": s:colors.searchForeground, "bg": s:colors.searchBackground})
+call s:h("Visual", {"fg": s:colors.selectionForeground, "bg": s:colors.selectionBackground})
+call s:h("PmenuSel", {"fg": s:colors.selectionForeground, "bg": s:colors.selectionBackground})
+call s:h("Folded", {"fg": s:colors.comments, "bg": s:colors.foldedTextBackground})
+
+" Git
+call s:h("gitcommitHeader", { "fg": s:colors.classNameColor})
+
+" Shell
+call s:h("shQuote", { "fg": s:colors.stringColor})
+call s:h("shSingleQuote", { "fg": s:colors.stringColor})
+call s:h("shHereDoc", { "fg": s:colors.stringColor, "bg": s:colors.codeBlock})
+call s:h("shDoubleQuote", { "fg": s:colors.stringColor})
+
+" XML
+call s:h("xmlAttrib", { "fg": s:colors.editorAccentColor})
+call s:h("xmlDoctype", { "fg": s:colors.editorAccentColor})
+call s:h("xmlDocTypeKeyword", { "fg": s:colors.htmlTagColor})
+call s:h("xmlDocTypeDecl", { "fg": s:colors.htmlTagColor})
+call s:h("xmlTag", { "fg": s:colors.foregroundColorEditor})
+call s:h("xmlTagName", { "fg": s:colors.htmlTagColor})
+call s:h("xmlEntity", { "fg": s:colors.constantColor})
+call s:h("xmlEntityPunct", { "fg": s:colors.constantColor})
+call s:h("xmlCdata", { "fg": s:colors.stringColor})
+call s:h("xmlString", { "fg": s:colors.stringColor})
+call s:h("xmlCdataStart", { "fg": s:colors.keywordColor})
+call s:h("xmlCdataEnd", { "fg": s:colors.keywordColor})
+call s:h("xmlCdataCdata", { "fg": s:colors.keywordColor})
+
+" Vim Script
+call s:h("vimOption", { "fg": s:colors.keyColor})
+call s:h("vimFuncName", { "fg": s:colors.editorAccentColor})
+call s:h("vimUserFunc", { "fg": s:colors.editorAccentColor})
+call s:h("vimParenSep", { "fg": s:colors.foregroundColorEditor})
+call s:h("vimCommand", { "fg": s:colors.keywordColor})
+call s:h("vimLet", { "fg": s:colors.keywordColor})
+call s:h("vimNotFunc", { "fg": s:colors.keywordColor})
+call s:h("vimIsCommand", { "fg": s:colors.classNameColor})
+
+" HTML
+call s:h("htmlTagName", { "fg": s:colors.htmlTagColor})
+call s:h("htmlEndTag", { "fg": s:colors.htmlTagColor})
+call s:h("htmlEndTag", { "fg": s:colors.foregroundColorEditor})
+call s:h("htmlHead", { "fg": s:colors.htmlTagColor})
+call s:h("htmlSpecialTagName", { "fg": s:colors.htmlTagColor})
+call s:h("htmlArg", { "fg": s:colors.editorAccentColor, "gui": "italic", "cterm": "italic"})
+call s:h("htmlTagN", { "fg": s:colors.htmlTagColor})
+call s:h("htmlScriptTag", { "fg": s:colors.foregroundColorEditor})
+call s:h("htmlTag", { "fg": s:colors.foregroundColorEditor})
+call s:h("htmlTitle", { "fg": s:colors.stringColor})
+call s:h("htmlH1", { "fg": s:colors.stringColor })
+call s:h("htmlH2", { "fg": s:colors.stringColor })
+call s:h("htmlH3", { "fg": s:colors.stringColor })
+call s:h("htmlH4", { "fg": s:colors.stringColor })
+call s:h("htmlH5", { "fg": s:colors.stringColor })
+call s:h("htmlH6", { "fg": s:colors.stringColor })
+call s:h("htmlLink", { "fg": s:colors.keyColor })
+call s:h("htmlSpecialChar", { "fg": s:colors.keywordColor})
+
+" Markdown
+call s:h("markdownH1", { "fg": s:colors.classNameColor})
+call s:h("markdownH2", { "fg": s:colors.classNameColor})
+call s:h("markdownH3", { "fg": s:colors.classNameColor})
+call s:h("markdownH4", { "fg": s:colors.classNameColor})
+call s:h("markdownH5", { "fg": s:colors.classNameColor})
+call s:h("markdownH6", { "fg": s:colors.classNameColor})
+call s:h("markdownH7", { "fg": s:colors.classNameColor})
+call s:h("markdownHeadingRule", { "fg": s:colors.classNameColor})
+call s:h("markdownBoldDelimiter", { "fg": s:colors.keywordColor})
+call s:h("markdownItalicDelimiter", { "fg": s:colors.keywordColor})
+call s:h("markdownAutomaticLink", { "fg": s:colors.keyColor})
+call s:h("markdownUrl", { "fg": s:colors.keyColor})
+call s:h("markdownUrlDelimiter", { "fg": s:colors.keyColor})
+call s:h("markdownLinkDelimiter", { "fg": s:colors.keyColor})
+call s:h("markdownLinkTextDelimiter", { "fg": s:colors.editorAccentColor})
+call s:h("markdownLinkText", { "fg": s:colors.editorAccentColor})
+call s:h("markdownId", { "fg": s:colors.keyColor})
+call s:h("markdownUrlTitle", { "fg": s:colors.comments})
+call s:h("markdownCode", { "fg": s:colors.comments})
+call s:h("markdownCodeBlock", { "fg": s:colors.comments})
+call s:h("markdownBlockQuote", { "fg": s:colors.keywordColor})
+call s:h("markdownUrlTitleDelimiter", { "fg": s:colors.comments})
+
+" Javascript
+call s:h("jsFuncCall", { "fg": s:colors.editorAccentColor})
+call s:h("jsDecoratorFunction", { "fg": s:colors.editorAccentColor})
+call s:h("jsDecorator", { "fg": s:colors.editorAccentColor})
+call s:h("jsRegexpString", { "fg": s:colors.editorAccentColor})
+call s:h("jsStorageClass", { "fg": s:colors.keywordColor})
+call s:h("jsThis", { "fg": s:colors.keywordColor})
+call s:h("jsOperatorKeyword", { "fg": s:colors.keywordColor})
+call s:h("jsVariableDef", { "fg": s:colors.foregroundColorEditor})
+call s:h("jsFuncBlock", { "fg": s:colors.foregroundColorEditor})
+call s:h("jsParens", { "fg": s:colors.foregroundColorEditor})
+call s:h("jsBrackets", { "fg": s:colors.foregroundColorEditor})
+call s:h("jsGlobalObjects", { "fg": s:colors.constantColor})
+call s:h("jsArrowFunction", { "fg": s:colors.htmlTagColor})
+call s:h("jsFunctionArgs", { "fg": s:colors.stringColor})
+call s:h("jsFuncArgs", { "fg": s:colors.stringColor})
+call s:h("jsObjectProp", { "fg": s:colors.foregroundColorEditor, "gui": "bold", "cterm": "bold"})
+call s:h("jsObjectKey", { "fg": s:colors.foregroundColorEditor, "gui": "bold", "cterm": "bold"})
+
+" JSON
+call s:h("jsObjectKey", { "fg": s:colors.foregroundColorEditor, "gui": "bold", "cterm": "bold"})
+call s:h("jsonKeyword", { "fg": s:colors.foregroundColorEditor})
+call s:h("jsonQuote", { "fg": s:colors.foregroundColorEditor})
+call s:h("jsonBraces", { "fg": s:colors.foregroundColorEditor})
+call s:h("jsonNull", { "fg": s:colors.keywordColor})
+call s:h("jsonBoolean", { "fg": s:colors.keywordColor})
+call s:h("jsonStringMatch", { "fg": s:colors.stringColor})
+
+" Typescript
+call s:h("typescriptBraces", { "fg": s:colors.foregroundColorEditor})
+call s:h("typescriptEndColons", { "fg": s:colors.foregroundColorEditor})
+call s:h("typescriptParens", { "fg": s:colors.foregroundColorEditor})
+call s:h("typescriptDecorators", { "fg": s:colors.editorAccentColor})
+call s:h("typescriptGlobalObjects", { "fg": s:colors.classNameColor})
+call s:h("typescriptDocTags", { "fg": s:colors.keyColor})
+call s:h("typescriptDocParam", { "fg": s:colors.stringColor})
+call s:h("typescriptIdentifier", { "fg": s:colors.keywordColor})
+
+" Java
+call s:h("javaExternal", { "fg": s:colors.keywordColor})
+call s:h("javaAnnotation", { "fg": s:colors.editorAccentColor})
+call s:h("javaParen", { "fg": s:colors.foregroundColorEditor})
+call s:h("javaDocTags", { "fg": s:colors.keyColor})
+call s:h("javaDocParam", { "fg": s:colors.stringColor})
+
+" Kotlin
+call s:h("ktInclude", { "fg": s:colors.keywordColor})
+call s:h("ktDocTagParam", { "fg": s:colors.stringColor})
+call s:h("ktAnnotation", { "fg": s:colors.editorAccentColor})
+call s:h("ktExclExcl", { "fg": s:colors.htmlTagColor})
+call s:h("ktArrow", { "fg": s:colors.foregroundColorEditor})
+
+" CSS
+call s:h("cssBraces", { "fg": s:colors.foregroundColorEditor})
+call s:h("cssTagName", { "fg": s:colors.editorAccentColor})
+call s:h("cssFunctionName", { "fg": s:colors.classNameColor})
+call s:h("cssFunction", { "fg": s:colors.editorAccentColor})
+call s:h("cssClassName", { "fg": s:colors.classNameColor})
+call s:h("cssAttributeSelector", { "fg": s:colors.classNameColor})
+call s:h("cssAtKeyword", { "fg": s:colors.keywordColor})
+call s:h("cssProp", { "fg": s:colors.keyColor})
+call s:h("cssPseudoClassId", { "fg": s:colors.stringColor})
+
+" Neovim-Specific Highlighting 
+
+if has("nvim")
+  " Neovim terminal colors 
+  "let g:terminal_color_0 =  s:black.gui
+  let g:terminal_color_1 =  s:colors.terminalAnsiMagenta.gui
+  let g:terminal_color_2 =  s:colors.terminalAnsiGreen.gui
+  let g:terminal_color_3 =  s:colors.terminalAnsiYellow.gui
+  let g:terminal_color_4 =  s:colors.terminalAnsiGreen.gui
+  let g:terminal_color_5 =  s:colors.terminalAnsiBlue.gui
+  let g:terminal_color_6 =  s:colors.terminalAnsiCyan.gui
+  "let g:terminal_color_7 =  s:white.gui
+ " let g:terminal_color_8 =  s:visual_grey.gui
+ " let g:terminal_color_9 =  s:dark_red.gui
+  let g:terminal_color_10 = s:colors.terminalAnsiGreen.gui " No dark version
+  let g:terminal_color_11 = s:colors.terminalAnsiYellow.gui
+  let g:terminal_color_12 = s:colors.terminalAnsiBlue.gui " No dark version
+  let g:terminal_color_13 = s:colors.terminalAnsiBlue.gui " No dark version
+  let g:terminal_color_14 = s:colors.terminalAnsiCyan.gui " No dark version
+  let g:terminal_color_15 = s:colors.comments.gui
+  let g:terminal_color_background = s:colors.textEditorBackground.gui
+  let g:terminal_color_foreground = s:colors.foregroundColorEditor.gui
+  " }}}
+
+  " Neovim Diagnostics 
+  call s:h("DiagnosticError", { "fg": s:colors.errorColor })
+  call s:h("DiagnosticWarn", { "fg": s:colors.terminalAnsiYellow })
+  call s:h("DiagnosticInfo", { "fg": s:colors.infoForeground })
+  call s:h("DiagnosticHint", { "fg": s:colors.terminalAnsiCyan })
+  call s:h("DiagnosticUnderlineError", { "fg": s:colors.errorColor, "gui": "underline", "cterm": "underline" })
+  call s:h("DiagnosticUnderlineWarn", { "fg": s:colors.terminalAnsiYellow, "gui": "underline", "cterm": "underline" })
+  call s:h("DiagnosticUnderlineInfo", { "fg": s:colors.terminalAnsiBlue, "gui": "underline", "cterm": "underline" })
+  call s:h("DiagnosticUnderlineHint", { "fg": s:colors.terminalAnsiCyan, "gui": "underline", "cterm": "underline" })
+  " }}}
+
+  " Neovim LSP (for versions < 0.5.1) 
+  hi link LspDiagnosticsDefaultError DiagnosticError
+  hi link LspDiagnosticsDefaultWarning DiagnosticWarn
+  hi link LspDiagnosticsDefaultInformation DiagnosticInfo
+  hi link LspDiagnosticsDefaultHint DiagnosticHint
+  hi link LspDiagnosticsUnderlineError DiagnosticUnderlineError
+  hi link LspDiagnosticsUnderlineWarning DiagnosticUnderlineWarn
+  hi link LspDiagnosticsUnderlineInformation DiagnosticUnderlineInfo
+  hi link LspDiagnosticsUnderlineHint DiagnosticUnderlineHint
+  " }}}
+endif

--- a/colors/nadeshiko.vim
+++ b/colors/nadeshiko.vim
@@ -1,0 +1,311 @@
+if v:version > 580
+  highlight clear
+  if exists('syntax_on')
+    syntax reset
+  endif
+endif
+
+let g:colors_name = 'nadeshiko'
+
+set t_Co=256
+
+" Set to "256" for 256-color terminals, or
+" set to "16" to use your terminal emulator's native colors
+" (a 16-color palette for this color scheme is available; see
+" < https://github.com/joshdick/
+" for more information.)
+if !exists("g:nadeshiko_termcolors")
+  let g:nadeshiko_termcolors = 256
+endif
+
+" Not all terminals support italics properly. If yours does, opt-in.
+if !exists("g:nadeshiko_terminal_italics")
+  let g:nadeshiko_terminal_italics = 0
+endif
+
+if !(has('termguicolors') && &termguicolors) && !has('gui_running') && &t_Co != 256
+  finish
+endif
+
+" This function is based on one from FlatColor: https://github.com/MaxSt/FlatColor/
+" Which in turn was based on one found in hemisu: https://github.com/noahfrederick/vim-hemisu/
+let s:group_colors = {} " Cache of default highlight group settings, for later reference via `
+function! s:h(group, style, ...)
+  if (a:0 > 0) " Will be true if we got here from 
+    let s:highlight = s:group_colors[a:group]
+    for style_type in ["fg", "bg", "sp"]
+      if (has_key(a:style, style_type))
+        let l:default_style = (has_key(s:highlight, style_type) ? copy(s:highlight[style_type]) : { "cterm16": "NONE", "cterm": "NONE", "gui": "NONE" })
+        let s:highlight[style_type] = extend(l:default_style, a:style[style_type])
+      endif
+    endfor
+    if (has_key(a:style, "gui"))
+      let s:highlight.gui = a:style.gui
+    endif
+  else
+    let s:highlight = a:style
+    let s:group_colors[a:group] = s:highlight " Cache default highlight group settings
+  endif
+
+  if g:nadeshiko_terminal_italics == 0
+    if has_key(s:highlight, "cterm") && s:highlight["cterm"] == "italic"
+      unlet s:highlight.cterm
+    endif
+    if has_key(s:highlight, "gui") && s:highlight["gui"] == "italic"
+      unlet s:highlight.gui
+    endif
+  endif
+
+  if g:nadeshiko_termcolors == 16
+    let l:ctermfg = (has_key(s:highlight, "fg") ? s:highlight.fg.cterm16 : "NONE")
+    let l:ctermbg = (has_key(s:highlight, "bg") ? s:highlight.bg.cterm16 : "NONE")
+  else
+    let l:ctermfg = (has_key(s:highlight, "fg") ? s:highlight.fg.cterm : "NONE")
+    let l:ctermbg = (has_key(s:highlight, "bg") ? s:highlight.bg.cterm : "NONE")
+  endif
+
+  execute "highlight" a:group
+    \ "guifg="   (has_key(s:highlight, "fg")    ? s:highlight.fg.gui   : "NONE")
+    \ "guibg="   (has_key(s:highlight, "bg")    ? s:highlight.bg.gui   : "NONE")
+    \ "guisp="   (has_key(s:highlight, "sp")    ? s:highlight.sp.gui   : "NONE")
+    \ "gui="     (has_key(s:highlight, "gui")   ? s:highlight.gui      : "NONE")
+    \ "ctermfg=" . l:ctermfg
+    \ "ctermbg=" . l:ctermbg
+    \ "cterm="   (has_key(s:highlight, "cterm") ? s:highlight.cterm    : "NONE")
+endfunction
+
+let s:colors = nadeshiko#GetColors() " Autoloaded from the specific color theme
+
+" Global colors
+call s:h("Comment", { "fg": s:colors.comments, "gui": "italic", "cterm": "italic" })
+call s:h("String", {"fg": s:colors.stringColor})
+call s:h("Constant", {"fg": s:colors.constantColor})
+call s:h("Identifier", {"fg": s:colors.foregroundColorEditor})
+call s:h("Function", {"fg": s:colors.classNameColor})
+call s:h("Underlined", {"fg": s:colors.keyColor})
+call s:h("Type", {"fg": s:colors.keyColor})
+call s:h("PreProc", {"fg": s:colors.keyColor})
+call s:h("StorageClass", {"fg": s:colors.keywordColor})
+call s:h("Keyword", {"fg": s:colors.keywordColor})
+call s:h("Statement", {"fg": s:colors.keywordColor})
+call s:h("SpecialChar", {"fg": s:colors.keyColor})
+call s:h("SpecialComment", {"fg": s:colors.keyColor})
+call s:h("Special", {"fg": s:colors.keyColor})
+call s:h("Operator", {"fg": s:colors.htmlTagColor})
+call s:h("foldBraces", {"fg": s:colors.foregroundColorEditor})
+call s:h("Error", {"fg": s:colors.errorColor, "gui": "underline", "cterm":"underline"})
+
+" VIM Stuff
+call s:h("Cursor", {"bg": s:colors.accentColor})
+call s:h("ColorColumn", {"bg": s:colors.caretRow})
+call s:h("CursorColumn", {"bg": s:colors.caretRow})
+call s:h("CursorLine", {"bg": s:colors.caretRow})
+call s:h("DiffAdd", {"bg": s:colors.diffInserted})
+call s:h("DiffChange", {"bg": s:colors.diffModified})
+call s:h("DiffDelete", {"bg": s:colors.diffDeleted})
+call s:h("DiffText", {"bg": s:colors.diffModified})
+call s:h("LineNr", {"fg": s:colors.lineNumberColor})
+call s:h("Pmenu", {"fg": s:colors.foregroundColorEditor})
+call s:h("Normal", {"fg": s:colors.foregroundColorEditor})
+call s:h("NonText", {"fg": s:colors.comments})
+call s:h("ModeMsg", {"fg": s:colors.infoForeground})
+call s:h("PmenuSbar", {"bg": s:colors.lightEditorColor})
+call s:h("PmenuThumb", {"bg": s:colors.accentColor})
+call s:h("ErrorMsg", {"bg": s:colors.errorColor})
+call s:h("VertSplit", {"fg": s:colors.lineNumberColor, "bg": s:colors.lightEditorColor})
+call s:h("StatusLine", {"fg": s:colors.foregroundColorEditor, "bg": s:colors.lightEditorColor})
+call s:h("StatusLineNc", {"fg": s:colors.lineNumberColor, "bg": s:colors.lightEditorColor})
+call s:h("Search", {"fg": s:colors.searchForeground, "bg": s:colors.searchBackground})
+call s:h("IncSearch", {"fg": s:colors.searchForeground, "bg": s:colors.searchBackground})
+call s:h("MatchParen", {"fg": s:colors.searchForeground, "bg": s:colors.searchBackground})
+call s:h("Visual", {"fg": s:colors.selectionForeground, "bg": s:colors.selectionBackground})
+call s:h("PmenuSel", {"fg": s:colors.selectionForeground, "bg": s:colors.selectionBackground})
+call s:h("Folded", {"fg": s:colors.comments, "bg": s:colors.foldedTextBackground})
+
+" Git
+call s:h("gitcommitHeader", { "fg": s:colors.classNameColor})
+
+" Shell
+call s:h("shQuote", { "fg": s:colors.stringColor})
+call s:h("shSingleQuote", { "fg": s:colors.stringColor})
+call s:h("shHereDoc", { "fg": s:colors.stringColor, "bg": s:colors.codeBlock})
+call s:h("shDoubleQuote", { "fg": s:colors.stringColor})
+
+" XML
+call s:h("xmlAttrib", { "fg": s:colors.editorAccentColor})
+call s:h("xmlDoctype", { "fg": s:colors.editorAccentColor})
+call s:h("xmlDocTypeKeyword", { "fg": s:colors.htmlTagColor})
+call s:h("xmlDocTypeDecl", { "fg": s:colors.htmlTagColor})
+call s:h("xmlTag", { "fg": s:colors.foregroundColorEditor})
+call s:h("xmlTagName", { "fg": s:colors.htmlTagColor})
+call s:h("xmlEntity", { "fg": s:colors.constantColor})
+call s:h("xmlEntityPunct", { "fg": s:colors.constantColor})
+call s:h("xmlCdata", { "fg": s:colors.stringColor})
+call s:h("xmlString", { "fg": s:colors.stringColor})
+call s:h("xmlCdataStart", { "fg": s:colors.keywordColor})
+call s:h("xmlCdataEnd", { "fg": s:colors.keywordColor})
+call s:h("xmlCdataCdata", { "fg": s:colors.keywordColor})
+
+" Vim Script
+call s:h("vimOption", { "fg": s:colors.keyColor})
+call s:h("vimFuncName", { "fg": s:colors.editorAccentColor})
+call s:h("vimUserFunc", { "fg": s:colors.editorAccentColor})
+call s:h("vimParenSep", { "fg": s:colors.foregroundColorEditor})
+call s:h("vimCommand", { "fg": s:colors.keywordColor})
+call s:h("vimLet", { "fg": s:colors.keywordColor})
+call s:h("vimNotFunc", { "fg": s:colors.keywordColor})
+call s:h("vimIsCommand", { "fg": s:colors.classNameColor})
+
+" HTML
+call s:h("htmlTagName", { "fg": s:colors.htmlTagColor})
+call s:h("htmlEndTag", { "fg": s:colors.htmlTagColor})
+call s:h("htmlEndTag", { "fg": s:colors.foregroundColorEditor})
+call s:h("htmlHead", { "fg": s:colors.htmlTagColor})
+call s:h("htmlSpecialTagName", { "fg": s:colors.htmlTagColor})
+call s:h("htmlArg", { "fg": s:colors.editorAccentColor, "gui": "italic", "cterm": "italic"})
+call s:h("htmlTagN", { "fg": s:colors.htmlTagColor})
+call s:h("htmlScriptTag", { "fg": s:colors.foregroundColorEditor})
+call s:h("htmlTag", { "fg": s:colors.foregroundColorEditor})
+call s:h("htmlTitle", { "fg": s:colors.stringColor})
+call s:h("htmlH1", { "fg": s:colors.stringColor })
+call s:h("htmlH2", { "fg": s:colors.stringColor })
+call s:h("htmlH3", { "fg": s:colors.stringColor })
+call s:h("htmlH4", { "fg": s:colors.stringColor })
+call s:h("htmlH5", { "fg": s:colors.stringColor })
+call s:h("htmlH6", { "fg": s:colors.stringColor })
+call s:h("htmlLink", { "fg": s:colors.keyColor })
+call s:h("htmlSpecialChar", { "fg": s:colors.keywordColor})
+
+" Markdown
+call s:h("markdownH1", { "fg": s:colors.classNameColor})
+call s:h("markdownH2", { "fg": s:colors.classNameColor})
+call s:h("markdownH3", { "fg": s:colors.classNameColor})
+call s:h("markdownH4", { "fg": s:colors.classNameColor})
+call s:h("markdownH5", { "fg": s:colors.classNameColor})
+call s:h("markdownH6", { "fg": s:colors.classNameColor})
+call s:h("markdownH7", { "fg": s:colors.classNameColor})
+call s:h("markdownHeadingRule", { "fg": s:colors.classNameColor})
+call s:h("markdownBoldDelimiter", { "fg": s:colors.keywordColor})
+call s:h("markdownItalicDelimiter", { "fg": s:colors.keywordColor})
+call s:h("markdownAutomaticLink", { "fg": s:colors.keyColor})
+call s:h("markdownUrl", { "fg": s:colors.keyColor})
+call s:h("markdownUrlDelimiter", { "fg": s:colors.keyColor})
+call s:h("markdownLinkDelimiter", { "fg": s:colors.keyColor})
+call s:h("markdownLinkTextDelimiter", { "fg": s:colors.editorAccentColor})
+call s:h("markdownLinkText", { "fg": s:colors.editorAccentColor})
+call s:h("markdownId", { "fg": s:colors.keyColor})
+call s:h("markdownUrlTitle", { "fg": s:colors.comments})
+call s:h("markdownCode", { "fg": s:colors.comments})
+call s:h("markdownCodeBlock", { "fg": s:colors.comments})
+call s:h("markdownBlockQuote", { "fg": s:colors.keywordColor})
+call s:h("markdownUrlTitleDelimiter", { "fg": s:colors.comments})
+
+" Javascript
+call s:h("jsFuncCall", { "fg": s:colors.editorAccentColor})
+call s:h("jsDecoratorFunction", { "fg": s:colors.editorAccentColor})
+call s:h("jsDecorator", { "fg": s:colors.editorAccentColor})
+call s:h("jsRegexpString", { "fg": s:colors.editorAccentColor})
+call s:h("jsStorageClass", { "fg": s:colors.keywordColor})
+call s:h("jsThis", { "fg": s:colors.keywordColor})
+call s:h("jsOperatorKeyword", { "fg": s:colors.keywordColor})
+call s:h("jsVariableDef", { "fg": s:colors.foregroundColorEditor})
+call s:h("jsFuncBlock", { "fg": s:colors.foregroundColorEditor})
+call s:h("jsParens", { "fg": s:colors.foregroundColorEditor})
+call s:h("jsBrackets", { "fg": s:colors.foregroundColorEditor})
+call s:h("jsGlobalObjects", { "fg": s:colors.constantColor})
+call s:h("jsArrowFunction", { "fg": s:colors.htmlTagColor})
+call s:h("jsFunctionArgs", { "fg": s:colors.stringColor})
+call s:h("jsFuncArgs", { "fg": s:colors.stringColor})
+call s:h("jsObjectProp", { "fg": s:colors.foregroundColorEditor, "gui": "bold", "cterm": "bold"})
+call s:h("jsObjectKey", { "fg": s:colors.foregroundColorEditor, "gui": "bold", "cterm": "bold"})
+
+" JSON
+call s:h("jsObjectKey", { "fg": s:colors.foregroundColorEditor, "gui": "bold", "cterm": "bold"})
+call s:h("jsonKeyword", { "fg": s:colors.foregroundColorEditor})
+call s:h("jsonQuote", { "fg": s:colors.foregroundColorEditor})
+call s:h("jsonBraces", { "fg": s:colors.foregroundColorEditor})
+call s:h("jsonNull", { "fg": s:colors.keywordColor})
+call s:h("jsonBoolean", { "fg": s:colors.keywordColor})
+call s:h("jsonStringMatch", { "fg": s:colors.stringColor})
+
+" Typescript
+call s:h("typescriptBraces", { "fg": s:colors.foregroundColorEditor})
+call s:h("typescriptEndColons", { "fg": s:colors.foregroundColorEditor})
+call s:h("typescriptParens", { "fg": s:colors.foregroundColorEditor})
+call s:h("typescriptDecorators", { "fg": s:colors.editorAccentColor})
+call s:h("typescriptGlobalObjects", { "fg": s:colors.classNameColor})
+call s:h("typescriptDocTags", { "fg": s:colors.keyColor})
+call s:h("typescriptDocParam", { "fg": s:colors.stringColor})
+call s:h("typescriptIdentifier", { "fg": s:colors.keywordColor})
+
+" Java
+call s:h("javaExternal", { "fg": s:colors.keywordColor})
+call s:h("javaAnnotation", { "fg": s:colors.editorAccentColor})
+call s:h("javaParen", { "fg": s:colors.foregroundColorEditor})
+call s:h("javaDocTags", { "fg": s:colors.keyColor})
+call s:h("javaDocParam", { "fg": s:colors.stringColor})
+
+" Kotlin
+call s:h("ktInclude", { "fg": s:colors.keywordColor})
+call s:h("ktDocTagParam", { "fg": s:colors.stringColor})
+call s:h("ktAnnotation", { "fg": s:colors.editorAccentColor})
+call s:h("ktExclExcl", { "fg": s:colors.htmlTagColor})
+call s:h("ktArrow", { "fg": s:colors.foregroundColorEditor})
+
+" CSS
+call s:h("cssBraces", { "fg": s:colors.foregroundColorEditor})
+call s:h("cssTagName", { "fg": s:colors.editorAccentColor})
+call s:h("cssFunctionName", { "fg": s:colors.classNameColor})
+call s:h("cssFunction", { "fg": s:colors.editorAccentColor})
+call s:h("cssClassName", { "fg": s:colors.classNameColor})
+call s:h("cssAttributeSelector", { "fg": s:colors.classNameColor})
+call s:h("cssAtKeyword", { "fg": s:colors.keywordColor})
+call s:h("cssProp", { "fg": s:colors.keyColor})
+call s:h("cssPseudoClassId", { "fg": s:colors.stringColor})
+
+" Neovim-Specific Highlighting 
+
+if has("nvim")
+  " Neovim terminal colors 
+  "let g:terminal_color_0 =  s:black.gui
+  let g:terminal_color_1 =  s:colors.terminalAnsiMagenta.gui
+  let g:terminal_color_2 =  s:colors.terminalAnsiGreen.gui
+  let g:terminal_color_3 =  s:colors.terminalAnsiYellow.gui
+  let g:terminal_color_4 =  s:colors.terminalAnsiGreen.gui
+  let g:terminal_color_5 =  s:colors.terminalAnsiBlue.gui
+  let g:terminal_color_6 =  s:colors.terminalAnsiCyan.gui
+  "let g:terminal_color_7 =  s:white.gui
+ " let g:terminal_color_8 =  s:visual_grey.gui
+ " let g:terminal_color_9 =  s:dark_red.gui
+  let g:terminal_color_10 = s:colors.terminalAnsiGreen.gui " No dark version
+  let g:terminal_color_11 = s:colors.terminalAnsiYellow.gui
+  let g:terminal_color_12 = s:colors.terminalAnsiBlue.gui " No dark version
+  let g:terminal_color_13 = s:colors.terminalAnsiBlue.gui " No dark version
+  let g:terminal_color_14 = s:colors.terminalAnsiCyan.gui " No dark version
+  let g:terminal_color_15 = s:colors.comments.gui
+  let g:terminal_color_background = s:colors.textEditorBackground.gui
+  let g:terminal_color_foreground = s:colors.foregroundColorEditor.gui
+  " }}}
+
+  " Neovim Diagnostics 
+  call s:h("DiagnosticError", { "fg": s:colors.errorColor })
+  call s:h("DiagnosticWarn", { "fg": s:colors.terminalAnsiYellow })
+  call s:h("DiagnosticInfo", { "fg": s:colors.infoForeground })
+  call s:h("DiagnosticHint", { "fg": s:colors.terminalAnsiCyan })
+  call s:h("DiagnosticUnderlineError", { "fg": s:colors.errorColor, "gui": "underline", "cterm": "underline" })
+  call s:h("DiagnosticUnderlineWarn", { "fg": s:colors.terminalAnsiYellow, "gui": "underline", "cterm": "underline" })
+  call s:h("DiagnosticUnderlineInfo", { "fg": s:colors.terminalAnsiBlue, "gui": "underline", "cterm": "underline" })
+  call s:h("DiagnosticUnderlineHint", { "fg": s:colors.terminalAnsiCyan, "gui": "underline", "cterm": "underline" })
+  " }}}
+
+  " Neovim LSP (for versions < 0.5.1) 
+  hi link LspDiagnosticsDefaultError DiagnosticError
+  hi link LspDiagnosticsDefaultWarning DiagnosticWarn
+  hi link LspDiagnosticsDefaultInformation DiagnosticInfo
+  hi link LspDiagnosticsDefaultHint DiagnosticHint
+  hi link LspDiagnosticsUnderlineError DiagnosticUnderlineError
+  hi link LspDiagnosticsUnderlineWarning DiagnosticUnderlineWarn
+  hi link LspDiagnosticsUnderlineInformation DiagnosticUnderlineInfo
+  hi link LspDiagnosticsUnderlineHint DiagnosticUnderlineHint
+  " }}}
+endif

--- a/colors/raphtalia.vim
+++ b/colors/raphtalia.vim
@@ -1,0 +1,311 @@
+if v:version > 580
+  highlight clear
+  if exists('syntax_on')
+    syntax reset
+  endif
+endif
+
+let g:colors_name = 'raphtalia'
+
+set t_Co=256
+
+" Set to "256" for 256-color terminals, or
+" set to "16" to use your terminal emulator's native colors
+" (a 16-color palette for this color scheme is available; see
+" < https://github.com/joshdick/
+" for more information.)
+if !exists("g:raphtalia_termcolors")
+  let g:raphtalia_termcolors = 256
+endif
+
+" Not all terminals support italics properly. If yours does, opt-in.
+if !exists("g:raphtalia_terminal_italics")
+  let g:raphtalia_terminal_italics = 0
+endif
+
+if !(has('termguicolors') && &termguicolors) && !has('gui_running') && &t_Co != 256
+  finish
+endif
+
+" This function is based on one from FlatColor: https://github.com/MaxSt/FlatColor/
+" Which in turn was based on one found in hemisu: https://github.com/noahfrederick/vim-hemisu/
+let s:group_colors = {} " Cache of default highlight group settings, for later reference via `
+function! s:h(group, style, ...)
+  if (a:0 > 0) " Will be true if we got here from 
+    let s:highlight = s:group_colors[a:group]
+    for style_type in ["fg", "bg", "sp"]
+      if (has_key(a:style, style_type))
+        let l:default_style = (has_key(s:highlight, style_type) ? copy(s:highlight[style_type]) : { "cterm16": "NONE", "cterm": "NONE", "gui": "NONE" })
+        let s:highlight[style_type] = extend(l:default_style, a:style[style_type])
+      endif
+    endfor
+    if (has_key(a:style, "gui"))
+      let s:highlight.gui = a:style.gui
+    endif
+  else
+    let s:highlight = a:style
+    let s:group_colors[a:group] = s:highlight " Cache default highlight group settings
+  endif
+
+  if g:raphtalia_terminal_italics == 0
+    if has_key(s:highlight, "cterm") && s:highlight["cterm"] == "italic"
+      unlet s:highlight.cterm
+    endif
+    if has_key(s:highlight, "gui") && s:highlight["gui"] == "italic"
+      unlet s:highlight.gui
+    endif
+  endif
+
+  if g:raphtalia_termcolors == 16
+    let l:ctermfg = (has_key(s:highlight, "fg") ? s:highlight.fg.cterm16 : "NONE")
+    let l:ctermbg = (has_key(s:highlight, "bg") ? s:highlight.bg.cterm16 : "NONE")
+  else
+    let l:ctermfg = (has_key(s:highlight, "fg") ? s:highlight.fg.cterm : "NONE")
+    let l:ctermbg = (has_key(s:highlight, "bg") ? s:highlight.bg.cterm : "NONE")
+  endif
+
+  execute "highlight" a:group
+    \ "guifg="   (has_key(s:highlight, "fg")    ? s:highlight.fg.gui   : "NONE")
+    \ "guibg="   (has_key(s:highlight, "bg")    ? s:highlight.bg.gui   : "NONE")
+    \ "guisp="   (has_key(s:highlight, "sp")    ? s:highlight.sp.gui   : "NONE")
+    \ "gui="     (has_key(s:highlight, "gui")   ? s:highlight.gui      : "NONE")
+    \ "ctermfg=" . l:ctermfg
+    \ "ctermbg=" . l:ctermbg
+    \ "cterm="   (has_key(s:highlight, "cterm") ? s:highlight.cterm    : "NONE")
+endfunction
+
+let s:colors = raphtalia#GetColors() " Autoloaded from the specific color theme
+
+" Global colors
+call s:h("Comment", { "fg": s:colors.comments, "gui": "italic", "cterm": "italic" })
+call s:h("String", {"fg": s:colors.stringColor})
+call s:h("Constant", {"fg": s:colors.constantColor})
+call s:h("Identifier", {"fg": s:colors.foregroundColorEditor})
+call s:h("Function", {"fg": s:colors.classNameColor})
+call s:h("Underlined", {"fg": s:colors.keyColor})
+call s:h("Type", {"fg": s:colors.keyColor})
+call s:h("PreProc", {"fg": s:colors.keyColor})
+call s:h("StorageClass", {"fg": s:colors.keywordColor})
+call s:h("Keyword", {"fg": s:colors.keywordColor})
+call s:h("Statement", {"fg": s:colors.keywordColor})
+call s:h("SpecialChar", {"fg": s:colors.keyColor})
+call s:h("SpecialComment", {"fg": s:colors.keyColor})
+call s:h("Special", {"fg": s:colors.keyColor})
+call s:h("Operator", {"fg": s:colors.htmlTagColor})
+call s:h("foldBraces", {"fg": s:colors.foregroundColorEditor})
+call s:h("Error", {"fg": s:colors.errorColor, "gui": "underline", "cterm":"underline"})
+
+" VIM Stuff
+call s:h("Cursor", {"bg": s:colors.accentColor})
+call s:h("ColorColumn", {"bg": s:colors.caretRow})
+call s:h("CursorColumn", {"bg": s:colors.caretRow})
+call s:h("CursorLine", {"bg": s:colors.caretRow})
+call s:h("DiffAdd", {"bg": s:colors.diffInserted})
+call s:h("DiffChange", {"bg": s:colors.diffModified})
+call s:h("DiffDelete", {"bg": s:colors.diffDeleted})
+call s:h("DiffText", {"bg": s:colors.diffModified})
+call s:h("LineNr", {"fg": s:colors.lineNumberColor})
+call s:h("Pmenu", {"fg": s:colors.foregroundColorEditor})
+call s:h("Normal", {"fg": s:colors.foregroundColorEditor})
+call s:h("NonText", {"fg": s:colors.comments})
+call s:h("ModeMsg", {"fg": s:colors.infoForeground})
+call s:h("PmenuSbar", {"bg": s:colors.lightEditorColor})
+call s:h("PmenuThumb", {"bg": s:colors.accentColor})
+call s:h("ErrorMsg", {"bg": s:colors.errorColor})
+call s:h("VertSplit", {"fg": s:colors.lineNumberColor, "bg": s:colors.lightEditorColor})
+call s:h("StatusLine", {"fg": s:colors.foregroundColorEditor, "bg": s:colors.lightEditorColor})
+call s:h("StatusLineNc", {"fg": s:colors.lineNumberColor, "bg": s:colors.lightEditorColor})
+call s:h("Search", {"fg": s:colors.searchForeground, "bg": s:colors.searchBackground})
+call s:h("IncSearch", {"fg": s:colors.searchForeground, "bg": s:colors.searchBackground})
+call s:h("MatchParen", {"fg": s:colors.searchForeground, "bg": s:colors.searchBackground})
+call s:h("Visual", {"fg": s:colors.selectionForeground, "bg": s:colors.selectionBackground})
+call s:h("PmenuSel", {"fg": s:colors.selectionForeground, "bg": s:colors.selectionBackground})
+call s:h("Folded", {"fg": s:colors.comments, "bg": s:colors.foldedTextBackground})
+
+" Git
+call s:h("gitcommitHeader", { "fg": s:colors.classNameColor})
+
+" Shell
+call s:h("shQuote", { "fg": s:colors.stringColor})
+call s:h("shSingleQuote", { "fg": s:colors.stringColor})
+call s:h("shHereDoc", { "fg": s:colors.stringColor, "bg": s:colors.codeBlock})
+call s:h("shDoubleQuote", { "fg": s:colors.stringColor})
+
+" XML
+call s:h("xmlAttrib", { "fg": s:colors.editorAccentColor})
+call s:h("xmlDoctype", { "fg": s:colors.editorAccentColor})
+call s:h("xmlDocTypeKeyword", { "fg": s:colors.htmlTagColor})
+call s:h("xmlDocTypeDecl", { "fg": s:colors.htmlTagColor})
+call s:h("xmlTag", { "fg": s:colors.foregroundColorEditor})
+call s:h("xmlTagName", { "fg": s:colors.htmlTagColor})
+call s:h("xmlEntity", { "fg": s:colors.constantColor})
+call s:h("xmlEntityPunct", { "fg": s:colors.constantColor})
+call s:h("xmlCdata", { "fg": s:colors.stringColor})
+call s:h("xmlString", { "fg": s:colors.stringColor})
+call s:h("xmlCdataStart", { "fg": s:colors.keywordColor})
+call s:h("xmlCdataEnd", { "fg": s:colors.keywordColor})
+call s:h("xmlCdataCdata", { "fg": s:colors.keywordColor})
+
+" Vim Script
+call s:h("vimOption", { "fg": s:colors.keyColor})
+call s:h("vimFuncName", { "fg": s:colors.editorAccentColor})
+call s:h("vimUserFunc", { "fg": s:colors.editorAccentColor})
+call s:h("vimParenSep", { "fg": s:colors.foregroundColorEditor})
+call s:h("vimCommand", { "fg": s:colors.keywordColor})
+call s:h("vimLet", { "fg": s:colors.keywordColor})
+call s:h("vimNotFunc", { "fg": s:colors.keywordColor})
+call s:h("vimIsCommand", { "fg": s:colors.classNameColor})
+
+" HTML
+call s:h("htmlTagName", { "fg": s:colors.htmlTagColor})
+call s:h("htmlEndTag", { "fg": s:colors.htmlTagColor})
+call s:h("htmlEndTag", { "fg": s:colors.foregroundColorEditor})
+call s:h("htmlHead", { "fg": s:colors.htmlTagColor})
+call s:h("htmlSpecialTagName", { "fg": s:colors.htmlTagColor})
+call s:h("htmlArg", { "fg": s:colors.editorAccentColor, "gui": "italic", "cterm": "italic"})
+call s:h("htmlTagN", { "fg": s:colors.htmlTagColor})
+call s:h("htmlScriptTag", { "fg": s:colors.foregroundColorEditor})
+call s:h("htmlTag", { "fg": s:colors.foregroundColorEditor})
+call s:h("htmlTitle", { "fg": s:colors.stringColor})
+call s:h("htmlH1", { "fg": s:colors.stringColor })
+call s:h("htmlH2", { "fg": s:colors.stringColor })
+call s:h("htmlH3", { "fg": s:colors.stringColor })
+call s:h("htmlH4", { "fg": s:colors.stringColor })
+call s:h("htmlH5", { "fg": s:colors.stringColor })
+call s:h("htmlH6", { "fg": s:colors.stringColor })
+call s:h("htmlLink", { "fg": s:colors.keyColor })
+call s:h("htmlSpecialChar", { "fg": s:colors.keywordColor})
+
+" Markdown
+call s:h("markdownH1", { "fg": s:colors.classNameColor})
+call s:h("markdownH2", { "fg": s:colors.classNameColor})
+call s:h("markdownH3", { "fg": s:colors.classNameColor})
+call s:h("markdownH4", { "fg": s:colors.classNameColor})
+call s:h("markdownH5", { "fg": s:colors.classNameColor})
+call s:h("markdownH6", { "fg": s:colors.classNameColor})
+call s:h("markdownH7", { "fg": s:colors.classNameColor})
+call s:h("markdownHeadingRule", { "fg": s:colors.classNameColor})
+call s:h("markdownBoldDelimiter", { "fg": s:colors.keywordColor})
+call s:h("markdownItalicDelimiter", { "fg": s:colors.keywordColor})
+call s:h("markdownAutomaticLink", { "fg": s:colors.keyColor})
+call s:h("markdownUrl", { "fg": s:colors.keyColor})
+call s:h("markdownUrlDelimiter", { "fg": s:colors.keyColor})
+call s:h("markdownLinkDelimiter", { "fg": s:colors.keyColor})
+call s:h("markdownLinkTextDelimiter", { "fg": s:colors.editorAccentColor})
+call s:h("markdownLinkText", { "fg": s:colors.editorAccentColor})
+call s:h("markdownId", { "fg": s:colors.keyColor})
+call s:h("markdownUrlTitle", { "fg": s:colors.comments})
+call s:h("markdownCode", { "fg": s:colors.comments})
+call s:h("markdownCodeBlock", { "fg": s:colors.comments})
+call s:h("markdownBlockQuote", { "fg": s:colors.keywordColor})
+call s:h("markdownUrlTitleDelimiter", { "fg": s:colors.comments})
+
+" Javascript
+call s:h("jsFuncCall", { "fg": s:colors.editorAccentColor})
+call s:h("jsDecoratorFunction", { "fg": s:colors.editorAccentColor})
+call s:h("jsDecorator", { "fg": s:colors.editorAccentColor})
+call s:h("jsRegexpString", { "fg": s:colors.editorAccentColor})
+call s:h("jsStorageClass", { "fg": s:colors.keywordColor})
+call s:h("jsThis", { "fg": s:colors.keywordColor})
+call s:h("jsOperatorKeyword", { "fg": s:colors.keywordColor})
+call s:h("jsVariableDef", { "fg": s:colors.foregroundColorEditor})
+call s:h("jsFuncBlock", { "fg": s:colors.foregroundColorEditor})
+call s:h("jsParens", { "fg": s:colors.foregroundColorEditor})
+call s:h("jsBrackets", { "fg": s:colors.foregroundColorEditor})
+call s:h("jsGlobalObjects", { "fg": s:colors.constantColor})
+call s:h("jsArrowFunction", { "fg": s:colors.htmlTagColor})
+call s:h("jsFunctionArgs", { "fg": s:colors.stringColor})
+call s:h("jsFuncArgs", { "fg": s:colors.stringColor})
+call s:h("jsObjectProp", { "fg": s:colors.foregroundColorEditor, "gui": "bold", "cterm": "bold"})
+call s:h("jsObjectKey", { "fg": s:colors.foregroundColorEditor, "gui": "bold", "cterm": "bold"})
+
+" JSON
+call s:h("jsObjectKey", { "fg": s:colors.foregroundColorEditor, "gui": "bold", "cterm": "bold"})
+call s:h("jsonKeyword", { "fg": s:colors.foregroundColorEditor})
+call s:h("jsonQuote", { "fg": s:colors.foregroundColorEditor})
+call s:h("jsonBraces", { "fg": s:colors.foregroundColorEditor})
+call s:h("jsonNull", { "fg": s:colors.keywordColor})
+call s:h("jsonBoolean", { "fg": s:colors.keywordColor})
+call s:h("jsonStringMatch", { "fg": s:colors.stringColor})
+
+" Typescript
+call s:h("typescriptBraces", { "fg": s:colors.foregroundColorEditor})
+call s:h("typescriptEndColons", { "fg": s:colors.foregroundColorEditor})
+call s:h("typescriptParens", { "fg": s:colors.foregroundColorEditor})
+call s:h("typescriptDecorators", { "fg": s:colors.editorAccentColor})
+call s:h("typescriptGlobalObjects", { "fg": s:colors.classNameColor})
+call s:h("typescriptDocTags", { "fg": s:colors.keyColor})
+call s:h("typescriptDocParam", { "fg": s:colors.stringColor})
+call s:h("typescriptIdentifier", { "fg": s:colors.keywordColor})
+
+" Java
+call s:h("javaExternal", { "fg": s:colors.keywordColor})
+call s:h("javaAnnotation", { "fg": s:colors.editorAccentColor})
+call s:h("javaParen", { "fg": s:colors.foregroundColorEditor})
+call s:h("javaDocTags", { "fg": s:colors.keyColor})
+call s:h("javaDocParam", { "fg": s:colors.stringColor})
+
+" Kotlin
+call s:h("ktInclude", { "fg": s:colors.keywordColor})
+call s:h("ktDocTagParam", { "fg": s:colors.stringColor})
+call s:h("ktAnnotation", { "fg": s:colors.editorAccentColor})
+call s:h("ktExclExcl", { "fg": s:colors.htmlTagColor})
+call s:h("ktArrow", { "fg": s:colors.foregroundColorEditor})
+
+" CSS
+call s:h("cssBraces", { "fg": s:colors.foregroundColorEditor})
+call s:h("cssTagName", { "fg": s:colors.editorAccentColor})
+call s:h("cssFunctionName", { "fg": s:colors.classNameColor})
+call s:h("cssFunction", { "fg": s:colors.editorAccentColor})
+call s:h("cssClassName", { "fg": s:colors.classNameColor})
+call s:h("cssAttributeSelector", { "fg": s:colors.classNameColor})
+call s:h("cssAtKeyword", { "fg": s:colors.keywordColor})
+call s:h("cssProp", { "fg": s:colors.keyColor})
+call s:h("cssPseudoClassId", { "fg": s:colors.stringColor})
+
+" Neovim-Specific Highlighting 
+
+if has("nvim")
+  " Neovim terminal colors 
+  "let g:terminal_color_0 =  s:black.gui
+  let g:terminal_color_1 =  s:colors.terminalAnsiMagenta.gui
+  let g:terminal_color_2 =  s:colors.terminalAnsiGreen.gui
+  let g:terminal_color_3 =  s:colors.terminalAnsiYellow.gui
+  let g:terminal_color_4 =  s:colors.terminalAnsiGreen.gui
+  let g:terminal_color_5 =  s:colors.terminalAnsiBlue.gui
+  let g:terminal_color_6 =  s:colors.terminalAnsiCyan.gui
+  "let g:terminal_color_7 =  s:white.gui
+ " let g:terminal_color_8 =  s:visual_grey.gui
+ " let g:terminal_color_9 =  s:dark_red.gui
+  let g:terminal_color_10 = s:colors.terminalAnsiGreen.gui " No dark version
+  let g:terminal_color_11 = s:colors.terminalAnsiYellow.gui
+  let g:terminal_color_12 = s:colors.terminalAnsiBlue.gui " No dark version
+  let g:terminal_color_13 = s:colors.terminalAnsiBlue.gui " No dark version
+  let g:terminal_color_14 = s:colors.terminalAnsiCyan.gui " No dark version
+  let g:terminal_color_15 = s:colors.comments.gui
+  let g:terminal_color_background = s:colors.textEditorBackground.gui
+  let g:terminal_color_foreground = s:colors.foregroundColorEditor.gui
+  " }}}
+
+  " Neovim Diagnostics 
+  call s:h("DiagnosticError", { "fg": s:colors.errorColor })
+  call s:h("DiagnosticWarn", { "fg": s:colors.terminalAnsiYellow })
+  call s:h("DiagnosticInfo", { "fg": s:colors.infoForeground })
+  call s:h("DiagnosticHint", { "fg": s:colors.terminalAnsiCyan })
+  call s:h("DiagnosticUnderlineError", { "fg": s:colors.errorColor, "gui": "underline", "cterm": "underline" })
+  call s:h("DiagnosticUnderlineWarn", { "fg": s:colors.terminalAnsiYellow, "gui": "underline", "cterm": "underline" })
+  call s:h("DiagnosticUnderlineInfo", { "fg": s:colors.terminalAnsiBlue, "gui": "underline", "cterm": "underline" })
+  call s:h("DiagnosticUnderlineHint", { "fg": s:colors.terminalAnsiCyan, "gui": "underline", "cterm": "underline" })
+  " }}}
+
+  " Neovim LSP (for versions < 0.5.1) 
+  hi link LspDiagnosticsDefaultError DiagnosticError
+  hi link LspDiagnosticsDefaultWarning DiagnosticWarn
+  hi link LspDiagnosticsDefaultInformation DiagnosticInfo
+  hi link LspDiagnosticsDefaultHint DiagnosticHint
+  hi link LspDiagnosticsUnderlineError DiagnosticUnderlineError
+  hi link LspDiagnosticsUnderlineWarning DiagnosticUnderlineWarn
+  hi link LspDiagnosticsUnderlineInformation DiagnosticUnderlineInfo
+  hi link LspDiagnosticsUnderlineHint DiagnosticUnderlineHint
+  " }}}
+endif

--- a/colors/takanashi_rikka.vim
+++ b/colors/takanashi_rikka.vim
@@ -1,0 +1,311 @@
+if v:version > 580
+  highlight clear
+  if exists('syntax_on')
+    syntax reset
+  endif
+endif
+
+let g:colors_name = 'takanashi_rikka'
+
+set t_Co=256
+
+" Set to "256" for 256-color terminals, or
+" set to "16" to use your terminal emulator's native colors
+" (a 16-color palette for this color scheme is available; see
+" < https://github.com/joshdick/
+" for more information.)
+if !exists("g:takanashi_rikka_termcolors")
+  let g:takanashi_rikka_termcolors = 256
+endif
+
+" Not all terminals support italics properly. If yours does, opt-in.
+if !exists("g:takanashi_rikka_terminal_italics")
+  let g:takanashi_rikka_terminal_italics = 0
+endif
+
+if !(has('termguicolors') && &termguicolors) && !has('gui_running') && &t_Co != 256
+  finish
+endif
+
+" This function is based on one from FlatColor: https://github.com/MaxSt/FlatColor/
+" Which in turn was based on one found in hemisu: https://github.com/noahfrederick/vim-hemisu/
+let s:group_colors = {} " Cache of default highlight group settings, for later reference via `
+function! s:h(group, style, ...)
+  if (a:0 > 0) " Will be true if we got here from 
+    let s:highlight = s:group_colors[a:group]
+    for style_type in ["fg", "bg", "sp"]
+      if (has_key(a:style, style_type))
+        let l:default_style = (has_key(s:highlight, style_type) ? copy(s:highlight[style_type]) : { "cterm16": "NONE", "cterm": "NONE", "gui": "NONE" })
+        let s:highlight[style_type] = extend(l:default_style, a:style[style_type])
+      endif
+    endfor
+    if (has_key(a:style, "gui"))
+      let s:highlight.gui = a:style.gui
+    endif
+  else
+    let s:highlight = a:style
+    let s:group_colors[a:group] = s:highlight " Cache default highlight group settings
+  endif
+
+  if g:takanashi_rikka_terminal_italics == 0
+    if has_key(s:highlight, "cterm") && s:highlight["cterm"] == "italic"
+      unlet s:highlight.cterm
+    endif
+    if has_key(s:highlight, "gui") && s:highlight["gui"] == "italic"
+      unlet s:highlight.gui
+    endif
+  endif
+
+  if g:takanashi_rikka_termcolors == 16
+    let l:ctermfg = (has_key(s:highlight, "fg") ? s:highlight.fg.cterm16 : "NONE")
+    let l:ctermbg = (has_key(s:highlight, "bg") ? s:highlight.bg.cterm16 : "NONE")
+  else
+    let l:ctermfg = (has_key(s:highlight, "fg") ? s:highlight.fg.cterm : "NONE")
+    let l:ctermbg = (has_key(s:highlight, "bg") ? s:highlight.bg.cterm : "NONE")
+  endif
+
+  execute "highlight" a:group
+    \ "guifg="   (has_key(s:highlight, "fg")    ? s:highlight.fg.gui   : "NONE")
+    \ "guibg="   (has_key(s:highlight, "bg")    ? s:highlight.bg.gui   : "NONE")
+    \ "guisp="   (has_key(s:highlight, "sp")    ? s:highlight.sp.gui   : "NONE")
+    \ "gui="     (has_key(s:highlight, "gui")   ? s:highlight.gui      : "NONE")
+    \ "ctermfg=" . l:ctermfg
+    \ "ctermbg=" . l:ctermbg
+    \ "cterm="   (has_key(s:highlight, "cterm") ? s:highlight.cterm    : "NONE")
+endfunction
+
+let s:colors = takanashi_rikka#GetColors() " Autoloaded from the specific color theme
+
+" Global colors
+call s:h("Comment", { "fg": s:colors.comments, "gui": "italic", "cterm": "italic" })
+call s:h("String", {"fg": s:colors.stringColor})
+call s:h("Constant", {"fg": s:colors.constantColor})
+call s:h("Identifier", {"fg": s:colors.foregroundColorEditor})
+call s:h("Function", {"fg": s:colors.classNameColor})
+call s:h("Underlined", {"fg": s:colors.keyColor})
+call s:h("Type", {"fg": s:colors.keyColor})
+call s:h("PreProc", {"fg": s:colors.keyColor})
+call s:h("StorageClass", {"fg": s:colors.keywordColor})
+call s:h("Keyword", {"fg": s:colors.keywordColor})
+call s:h("Statement", {"fg": s:colors.keywordColor})
+call s:h("SpecialChar", {"fg": s:colors.keyColor})
+call s:h("SpecialComment", {"fg": s:colors.keyColor})
+call s:h("Special", {"fg": s:colors.keyColor})
+call s:h("Operator", {"fg": s:colors.htmlTagColor})
+call s:h("foldBraces", {"fg": s:colors.foregroundColorEditor})
+call s:h("Error", {"fg": s:colors.errorColor, "gui": "underline", "cterm":"underline"})
+
+" VIM Stuff
+call s:h("Cursor", {"bg": s:colors.accentColor})
+call s:h("ColorColumn", {"bg": s:colors.caretRow})
+call s:h("CursorColumn", {"bg": s:colors.caretRow})
+call s:h("CursorLine", {"bg": s:colors.caretRow})
+call s:h("DiffAdd", {"bg": s:colors.diffInserted})
+call s:h("DiffChange", {"bg": s:colors.diffModified})
+call s:h("DiffDelete", {"bg": s:colors.diffDeleted})
+call s:h("DiffText", {"bg": s:colors.diffModified})
+call s:h("LineNr", {"fg": s:colors.lineNumberColor})
+call s:h("Pmenu", {"fg": s:colors.foregroundColorEditor})
+call s:h("Normal", {"fg": s:colors.foregroundColorEditor})
+call s:h("NonText", {"fg": s:colors.comments})
+call s:h("ModeMsg", {"fg": s:colors.infoForeground})
+call s:h("PmenuSbar", {"bg": s:colors.lightEditorColor})
+call s:h("PmenuThumb", {"bg": s:colors.accentColor})
+call s:h("ErrorMsg", {"bg": s:colors.errorColor})
+call s:h("VertSplit", {"fg": s:colors.lineNumberColor, "bg": s:colors.lightEditorColor})
+call s:h("StatusLine", {"fg": s:colors.foregroundColorEditor, "bg": s:colors.lightEditorColor})
+call s:h("StatusLineNc", {"fg": s:colors.lineNumberColor, "bg": s:colors.lightEditorColor})
+call s:h("Search", {"fg": s:colors.searchForeground, "bg": s:colors.searchBackground})
+call s:h("IncSearch", {"fg": s:colors.searchForeground, "bg": s:colors.searchBackground})
+call s:h("MatchParen", {"fg": s:colors.searchForeground, "bg": s:colors.searchBackground})
+call s:h("Visual", {"fg": s:colors.selectionForeground, "bg": s:colors.selectionBackground})
+call s:h("PmenuSel", {"fg": s:colors.selectionForeground, "bg": s:colors.selectionBackground})
+call s:h("Folded", {"fg": s:colors.comments, "bg": s:colors.foldedTextBackground})
+
+" Git
+call s:h("gitcommitHeader", { "fg": s:colors.classNameColor})
+
+" Shell
+call s:h("shQuote", { "fg": s:colors.stringColor})
+call s:h("shSingleQuote", { "fg": s:colors.stringColor})
+call s:h("shHereDoc", { "fg": s:colors.stringColor, "bg": s:colors.codeBlock})
+call s:h("shDoubleQuote", { "fg": s:colors.stringColor})
+
+" XML
+call s:h("xmlAttrib", { "fg": s:colors.editorAccentColor})
+call s:h("xmlDoctype", { "fg": s:colors.editorAccentColor})
+call s:h("xmlDocTypeKeyword", { "fg": s:colors.htmlTagColor})
+call s:h("xmlDocTypeDecl", { "fg": s:colors.htmlTagColor})
+call s:h("xmlTag", { "fg": s:colors.foregroundColorEditor})
+call s:h("xmlTagName", { "fg": s:colors.htmlTagColor})
+call s:h("xmlEntity", { "fg": s:colors.constantColor})
+call s:h("xmlEntityPunct", { "fg": s:colors.constantColor})
+call s:h("xmlCdata", { "fg": s:colors.stringColor})
+call s:h("xmlString", { "fg": s:colors.stringColor})
+call s:h("xmlCdataStart", { "fg": s:colors.keywordColor})
+call s:h("xmlCdataEnd", { "fg": s:colors.keywordColor})
+call s:h("xmlCdataCdata", { "fg": s:colors.keywordColor})
+
+" Vim Script
+call s:h("vimOption", { "fg": s:colors.keyColor})
+call s:h("vimFuncName", { "fg": s:colors.editorAccentColor})
+call s:h("vimUserFunc", { "fg": s:colors.editorAccentColor})
+call s:h("vimParenSep", { "fg": s:colors.foregroundColorEditor})
+call s:h("vimCommand", { "fg": s:colors.keywordColor})
+call s:h("vimLet", { "fg": s:colors.keywordColor})
+call s:h("vimNotFunc", { "fg": s:colors.keywordColor})
+call s:h("vimIsCommand", { "fg": s:colors.classNameColor})
+
+" HTML
+call s:h("htmlTagName", { "fg": s:colors.htmlTagColor})
+call s:h("htmlEndTag", { "fg": s:colors.htmlTagColor})
+call s:h("htmlEndTag", { "fg": s:colors.foregroundColorEditor})
+call s:h("htmlHead", { "fg": s:colors.htmlTagColor})
+call s:h("htmlSpecialTagName", { "fg": s:colors.htmlTagColor})
+call s:h("htmlArg", { "fg": s:colors.editorAccentColor, "gui": "italic", "cterm": "italic"})
+call s:h("htmlTagN", { "fg": s:colors.htmlTagColor})
+call s:h("htmlScriptTag", { "fg": s:colors.foregroundColorEditor})
+call s:h("htmlTag", { "fg": s:colors.foregroundColorEditor})
+call s:h("htmlTitle", { "fg": s:colors.stringColor})
+call s:h("htmlH1", { "fg": s:colors.stringColor })
+call s:h("htmlH2", { "fg": s:colors.stringColor })
+call s:h("htmlH3", { "fg": s:colors.stringColor })
+call s:h("htmlH4", { "fg": s:colors.stringColor })
+call s:h("htmlH5", { "fg": s:colors.stringColor })
+call s:h("htmlH6", { "fg": s:colors.stringColor })
+call s:h("htmlLink", { "fg": s:colors.keyColor })
+call s:h("htmlSpecialChar", { "fg": s:colors.keywordColor})
+
+" Markdown
+call s:h("markdownH1", { "fg": s:colors.classNameColor})
+call s:h("markdownH2", { "fg": s:colors.classNameColor})
+call s:h("markdownH3", { "fg": s:colors.classNameColor})
+call s:h("markdownH4", { "fg": s:colors.classNameColor})
+call s:h("markdownH5", { "fg": s:colors.classNameColor})
+call s:h("markdownH6", { "fg": s:colors.classNameColor})
+call s:h("markdownH7", { "fg": s:colors.classNameColor})
+call s:h("markdownHeadingRule", { "fg": s:colors.classNameColor})
+call s:h("markdownBoldDelimiter", { "fg": s:colors.keywordColor})
+call s:h("markdownItalicDelimiter", { "fg": s:colors.keywordColor})
+call s:h("markdownAutomaticLink", { "fg": s:colors.keyColor})
+call s:h("markdownUrl", { "fg": s:colors.keyColor})
+call s:h("markdownUrlDelimiter", { "fg": s:colors.keyColor})
+call s:h("markdownLinkDelimiter", { "fg": s:colors.keyColor})
+call s:h("markdownLinkTextDelimiter", { "fg": s:colors.editorAccentColor})
+call s:h("markdownLinkText", { "fg": s:colors.editorAccentColor})
+call s:h("markdownId", { "fg": s:colors.keyColor})
+call s:h("markdownUrlTitle", { "fg": s:colors.comments})
+call s:h("markdownCode", { "fg": s:colors.comments})
+call s:h("markdownCodeBlock", { "fg": s:colors.comments})
+call s:h("markdownBlockQuote", { "fg": s:colors.keywordColor})
+call s:h("markdownUrlTitleDelimiter", { "fg": s:colors.comments})
+
+" Javascript
+call s:h("jsFuncCall", { "fg": s:colors.editorAccentColor})
+call s:h("jsDecoratorFunction", { "fg": s:colors.editorAccentColor})
+call s:h("jsDecorator", { "fg": s:colors.editorAccentColor})
+call s:h("jsRegexpString", { "fg": s:colors.editorAccentColor})
+call s:h("jsStorageClass", { "fg": s:colors.keywordColor})
+call s:h("jsThis", { "fg": s:colors.keywordColor})
+call s:h("jsOperatorKeyword", { "fg": s:colors.keywordColor})
+call s:h("jsVariableDef", { "fg": s:colors.foregroundColorEditor})
+call s:h("jsFuncBlock", { "fg": s:colors.foregroundColorEditor})
+call s:h("jsParens", { "fg": s:colors.foregroundColorEditor})
+call s:h("jsBrackets", { "fg": s:colors.foregroundColorEditor})
+call s:h("jsGlobalObjects", { "fg": s:colors.constantColor})
+call s:h("jsArrowFunction", { "fg": s:colors.htmlTagColor})
+call s:h("jsFunctionArgs", { "fg": s:colors.stringColor})
+call s:h("jsFuncArgs", { "fg": s:colors.stringColor})
+call s:h("jsObjectProp", { "fg": s:colors.foregroundColorEditor, "gui": "bold", "cterm": "bold"})
+call s:h("jsObjectKey", { "fg": s:colors.foregroundColorEditor, "gui": "bold", "cterm": "bold"})
+
+" JSON
+call s:h("jsObjectKey", { "fg": s:colors.foregroundColorEditor, "gui": "bold", "cterm": "bold"})
+call s:h("jsonKeyword", { "fg": s:colors.foregroundColorEditor})
+call s:h("jsonQuote", { "fg": s:colors.foregroundColorEditor})
+call s:h("jsonBraces", { "fg": s:colors.foregroundColorEditor})
+call s:h("jsonNull", { "fg": s:colors.keywordColor})
+call s:h("jsonBoolean", { "fg": s:colors.keywordColor})
+call s:h("jsonStringMatch", { "fg": s:colors.stringColor})
+
+" Typescript
+call s:h("typescriptBraces", { "fg": s:colors.foregroundColorEditor})
+call s:h("typescriptEndColons", { "fg": s:colors.foregroundColorEditor})
+call s:h("typescriptParens", { "fg": s:colors.foregroundColorEditor})
+call s:h("typescriptDecorators", { "fg": s:colors.editorAccentColor})
+call s:h("typescriptGlobalObjects", { "fg": s:colors.classNameColor})
+call s:h("typescriptDocTags", { "fg": s:colors.keyColor})
+call s:h("typescriptDocParam", { "fg": s:colors.stringColor})
+call s:h("typescriptIdentifier", { "fg": s:colors.keywordColor})
+
+" Java
+call s:h("javaExternal", { "fg": s:colors.keywordColor})
+call s:h("javaAnnotation", { "fg": s:colors.editorAccentColor})
+call s:h("javaParen", { "fg": s:colors.foregroundColorEditor})
+call s:h("javaDocTags", { "fg": s:colors.keyColor})
+call s:h("javaDocParam", { "fg": s:colors.stringColor})
+
+" Kotlin
+call s:h("ktInclude", { "fg": s:colors.keywordColor})
+call s:h("ktDocTagParam", { "fg": s:colors.stringColor})
+call s:h("ktAnnotation", { "fg": s:colors.editorAccentColor})
+call s:h("ktExclExcl", { "fg": s:colors.htmlTagColor})
+call s:h("ktArrow", { "fg": s:colors.foregroundColorEditor})
+
+" CSS
+call s:h("cssBraces", { "fg": s:colors.foregroundColorEditor})
+call s:h("cssTagName", { "fg": s:colors.editorAccentColor})
+call s:h("cssFunctionName", { "fg": s:colors.classNameColor})
+call s:h("cssFunction", { "fg": s:colors.editorAccentColor})
+call s:h("cssClassName", { "fg": s:colors.classNameColor})
+call s:h("cssAttributeSelector", { "fg": s:colors.classNameColor})
+call s:h("cssAtKeyword", { "fg": s:colors.keywordColor})
+call s:h("cssProp", { "fg": s:colors.keyColor})
+call s:h("cssPseudoClassId", { "fg": s:colors.stringColor})
+
+" Neovim-Specific Highlighting 
+
+if has("nvim")
+  " Neovim terminal colors 
+  "let g:terminal_color_0 =  s:black.gui
+  let g:terminal_color_1 =  s:colors.terminalAnsiMagenta.gui
+  let g:terminal_color_2 =  s:colors.terminalAnsiGreen.gui
+  let g:terminal_color_3 =  s:colors.terminalAnsiYellow.gui
+  let g:terminal_color_4 =  s:colors.terminalAnsiGreen.gui
+  let g:terminal_color_5 =  s:colors.terminalAnsiBlue.gui
+  let g:terminal_color_6 =  s:colors.terminalAnsiCyan.gui
+  "let g:terminal_color_7 =  s:white.gui
+ " let g:terminal_color_8 =  s:visual_grey.gui
+ " let g:terminal_color_9 =  s:dark_red.gui
+  let g:terminal_color_10 = s:colors.terminalAnsiGreen.gui " No dark version
+  let g:terminal_color_11 = s:colors.terminalAnsiYellow.gui
+  let g:terminal_color_12 = s:colors.terminalAnsiBlue.gui " No dark version
+  let g:terminal_color_13 = s:colors.terminalAnsiBlue.gui " No dark version
+  let g:terminal_color_14 = s:colors.terminalAnsiCyan.gui " No dark version
+  let g:terminal_color_15 = s:colors.comments.gui
+  let g:terminal_color_background = s:colors.textEditorBackground.gui
+  let g:terminal_color_foreground = s:colors.foregroundColorEditor.gui
+  " }}}
+
+  " Neovim Diagnostics 
+  call s:h("DiagnosticError", { "fg": s:colors.errorColor })
+  call s:h("DiagnosticWarn", { "fg": s:colors.terminalAnsiYellow })
+  call s:h("DiagnosticInfo", { "fg": s:colors.infoForeground })
+  call s:h("DiagnosticHint", { "fg": s:colors.terminalAnsiCyan })
+  call s:h("DiagnosticUnderlineError", { "fg": s:colors.errorColor, "gui": "underline", "cterm": "underline" })
+  call s:h("DiagnosticUnderlineWarn", { "fg": s:colors.terminalAnsiYellow, "gui": "underline", "cterm": "underline" })
+  call s:h("DiagnosticUnderlineInfo", { "fg": s:colors.terminalAnsiBlue, "gui": "underline", "cterm": "underline" })
+  call s:h("DiagnosticUnderlineHint", { "fg": s:colors.terminalAnsiCyan, "gui": "underline", "cterm": "underline" })
+  " }}}
+
+  " Neovim LSP (for versions < 0.5.1) 
+  hi link LspDiagnosticsDefaultError DiagnosticError
+  hi link LspDiagnosticsDefaultWarning DiagnosticWarn
+  hi link LspDiagnosticsDefaultInformation DiagnosticInfo
+  hi link LspDiagnosticsDefaultHint DiagnosticHint
+  hi link LspDiagnosticsUnderlineError DiagnosticUnderlineError
+  hi link LspDiagnosticsUnderlineWarning DiagnosticUnderlineWarn
+  hi link LspDiagnosticsUnderlineInformation DiagnosticUnderlineInfo
+  hi link LspDiagnosticsUnderlineHint DiagnosticUnderlineHint
+  " }}}
+endif

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doki-theme-vim",
-  "version": "15.0.0",
+  "version": "74.1-1.0.0",
   "description": "Complementary vim color scheme for your full Otaku cli experience. Works well with the Doki Theme for Hyper.js",
   "main": "index.js",
   "repository": "git@github.com:/doki-theme/doki-theme-vim.git",


### PR DESCRIPTION
## Changes

**4 New Dark Themes!**

- Decimate errors in the code alongside the Wicked Lord Shingan. Let your inner fantasies go rampant with Rikka Takanashi from: "Love, Chuunibyou, and Other Delusions". 
- It is comfy time! Don't let feature requests stress you out, because you can now code with Nadeshiko from Yuru Camp. 
- A Certain Scientific RailGun go: bzzzzzzt. Zap bugs out of existence with the electromaster Mikoto Misaka.
- Raccoon + Tanuki = one really cute cinnamon bun. Enjoy your time coding with Raphtalia from: "Rising of the Shield Hero."

![v74 Girls](https://doki.assets.unthrottled.io/misc/v74_girls.png)

### Other Stuff

- Updated Syntax Highlight & Look and Feel changes for the following legacy themes: Ibuki Dark, Astolfo, Aqua, Hatsune Miku, Emilia Dark, Ram, and Rem.

## Screens

**Takanashi Rikka**
![Screenshot from 2022-02-06 18-12-09](https://user-images.githubusercontent.com/15972415/152707964-3d9986cf-31c7-46ab-aa67-58533f8e4280.png)

**Nadeshiko**
![Screenshot from 2022-02-06 18-12-32](https://user-images.githubusercontent.com/15972415/152707962-77680d00-1fb8-4bb1-adf9-18b5caf51984.png)

**Misaka Mikoto**
![Screenshot from 2022-02-06 18-13-13](https://user-images.githubusercontent.com/15972415/152707958-b5c95d0f-1cef-40c3-a53e-38a426f16354.png)

**Raphtalia**
![Screenshot from 2022-02-06 18-13-31](https://user-images.githubusercontent.com/15972415/152707951-6be0ba90-9298-4047-be56-add74cbd223b.png)

